### PR TITLE
Fix exit on missing REPL history file

### DIFF
--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -57,7 +57,9 @@ pub fn run(opts: Opts) -> Result<(), Error> {
     let context = Context::default();
 
     if let Some(ref history_file) = opts.history_file {
-        rl.load_history(&history_file)?;
+        if let Err(_) = rl.load_history(&history_file) {
+            // No previous REPL history!
+        }
     }
 
     for (i, line) in LOGO_TEXT.iter().enumerate() {


### PR DESCRIPTION
Fixes #3

So the problem seems to be that Rustyline returns an error if `Editor::load_history` is called with a file name that does not exist. Fix is just to ignore the error. The file will be created for the first time when `Editor::save_history` is called on closing the REPL.