### PR TITLE
Bump codespan version to get pretty CLI reporting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ publish = false
 [features]
 default = ["cli"]
 cli = [
-    "isatty",
     "rustyline",
     "structopt",
     "term_size",
@@ -23,8 +22,8 @@ name = "pikelet"
 required-features = ["cli"]
 
 [dependencies]
-codespan = { git = "https://github.com/brendanzab/codespan", rev = "e25e243", version = "0.1.0" }
-codespan-reporting = { git = "https://github.com/brendanzab/codespan", rev = "e25e243", version = "0.1.0" }
+codespan = { git = "https://github.com/brendanzab/codespan", rev = "d5c18a0", version = "0.1.0" }
+codespan-reporting = { git = "https://github.com/brendanzab/codespan", rev = "d5c18a0", version = "0.1.0" }
 failure = "0.1.1"
 lalrpop-util = "0.15.1"
 nameless = { git = "https://github.com/brendanzab/nameless", rev = "9db2220", version = "0.1.0" }
@@ -34,7 +33,6 @@ rpds = "0.4.0"
 unicode-xid = "0.1.0"
 
 # cli dependencies
-isatty = { version = "0.1.6", optional = true }
 rustyline = { version = "1.0.0", optional = true }
 structopt = { version = "0.2.2", optional = true }
 term_size = { version = "0.3.0", optional = true }

--- a/book/src/index.md
+++ b/book/src/index.md
@@ -34,11 +34,11 @@ $ cargo run repl
 /_/   /_/_/|_|\___/_/\___/\__/      :? for help
 
 Pikelet> (\(a : Type) (x : a) => x) String "hello"
-"hello" : #String
+"hello" : String
 Pikelet> :t Type
 Type 1
 Pikelet> 1 : I16
-1 : #I16
+1 : I16
 Pikelet>
 ```
 

--- a/book/src/language/index.md
+++ b/book/src/language/index.md
@@ -91,7 +91,10 @@ Pikelet> 1 : F32
 Pikelet> 1.0 : F32
 1.0 : F32
 Pikelet> 1.1 : U64
-error: found a floating point literal, but expected a type `#U64`
+error: found a floating point literal, but expected a type `U64`
+- <repl>:1:1
+1 | 1.1 : U64
+  | ^^^ the literal
 ```
 
 ## Types of types
@@ -182,11 +185,10 @@ types:
 
 ```pikelet-repl
 Pikelet> (\x : I32 => x) 4.0
-error: found a floating point literal, but expected a type `#I32`
-Pikelet> (\x : String => x) 'b'
-error: found a character literal, but expected a type `#String`
-Pikelet> (\x : Char => x) "yoho"
-error: found a string literal, but expected a type `#Char`
+error: found a floating point literal, but expected a type `I32`
+- <repl>:1:17
+1 | (\x : I32 => x) 4.0
+  |                 ^^^ the literal
 ```
 
 Let's make this identity function polymorphic by adding a parameter for the type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,6 @@ pub mod semantics;
 pub mod syntax;
 
 #[cfg(feature = "cli")]
-extern crate isatty;
-#[cfg(feature = "cli")]
 extern crate rustyline;
 #[cfg(feature = "cli")]
 #[macro_use]
@@ -60,10 +58,10 @@ pub fn load_prelude(codemap: &mut CodeMap) -> Module {
 
     match load_file(&file) {
         Ok(module) => module,
-        Err(diagnostics) => {
-            for diagnostic in diagnostics {
-                codespan_reporting::emit(codemap, &diagnostic);
-            }
+        Err(_diagnostics) => {
+            // for diagnostic in diagnostics {
+            //     codespan_reporting::emit(codemap, &diagnostic);
+            // }
             panic!("unexpected parse errors in prelude");
         },
     }

--- a/src/semantics/errors.rs
+++ b/src/semantics/errors.rs
@@ -174,7 +174,7 @@ impl TypeError {
                 found, expected,
             )).with_label(Label::new_primary(span).with_message("the term")),
             TypeError::ExpectedUniverse { ref found, span } => {
-                Diagnostic::new_error(format!("expected type, found value `{}`", found))
+                Diagnostic::new_error(format!("expected type, found a value of type `{}`", found))
                     .with_label(Label::new_primary(span).with_message("the value"))
             },
             TypeError::UndefinedName { ref name, var_span } => {

--- a/src/semantics/tests.rs
+++ b/src/semantics/tests.rs
@@ -577,6 +577,7 @@ mod infer {
 
 mod check_module {
     use codespan_reporting;
+    use codespan_reporting::termcolor::{ColorChoice, StandardStream};
     use library;
 
     use super::*;
@@ -585,18 +586,20 @@ mod check_module {
     fn check_prelude() {
         let mut codemap = CodeMap::new();
         let filemap = codemap.add_filemap(FileName::virtual_("test"), library::PRELUDE.into());
+        let writer = StandardStream::stderr(ColorChoice::Always);
 
         let (concrete_module, errors) = parse::module(&filemap);
         if !errors.is_empty() {
             for error in errors {
-                codespan_reporting::emit(&codemap, &error.to_diagnostic());
+                codespan_reporting::emit(&mut writer.lock(), &codemap, &error.to_diagnostic())
+                    .unwrap();
             }
             panic!("parse error!")
         }
 
         let module = concrete_module.to_core();
         if let Err(err) = check_module(&module) {
-            codespan_reporting::emit(&codemap, &err.to_diagnostic());
+            codespan_reporting::emit(&mut writer.lock(), &codemap, &err.to_diagnostic()).unwrap();
             panic!("type error!")
         }
     }

--- a/src/syntax/translation/concrete_to_core.rs
+++ b/src/syntax/translation/concrete_to_core.rs
@@ -248,6 +248,7 @@ mod to_core {
 
     mod module {
         use codespan_reporting;
+        use codespan_reporting::termcolor::{ColorChoice, StandardStream};
 
         use super::*;
 
@@ -255,11 +256,13 @@ mod to_core {
         fn parse_prelude() {
             let mut codemap = CodeMap::new();
             let filemap = codemap.add_filemap(FileName::virtual_("test"), library::PRELUDE.into());
+            let writer = StandardStream::stderr(ColorChoice::Always);
 
             let (concrete_module, errors) = parse::module(&filemap);
             if !errors.is_empty() {
                 for error in errors {
-                    codespan_reporting::emit(&codemap, &error.to_diagnostic());
+                    codespan_reporting::emit(&mut writer.lock(), &codemap, &error.to_diagnostic())
+                        .unwrap();
                 }
                 panic!("parse error!")
             }


### PR DESCRIPTION
Thanks to @Marwes’ [contributions to codespan](https://github.com/brendanzab/codespan/pull/5), we now have some pretty error reporting!

<img width="475" alt="screen shot 2018-04-12 at 5 32 48 pm" src="https://user-images.githubusercontent.com/695077/38662564-1ad78c40-3e78-11e8-91cf-6ad33218c14c.png">

Closes #11