### PR TITLE
Dependent Records (first pass) 

### DIFF
--- a/book/src/language/records.md
+++ b/book/src/language/records.md
@@ -4,6 +4,7 @@
 
 - [Record values and record types](#record-values-and-record-types)
 - [Field lookups](#field-lookups)
+- [Dependent record types](#dependent_record_types)
 
 ## Record values and record types
 
@@ -47,4 +48,17 @@ You can access the value associated with a field by using the dot operator:
 ```pikelet-repl
 Pikelet> record { name = "Jane" }.name
 "Jane" : String
+```
+
+## Dependent record types
+
+Field types can depend on data from previous fields. Here we turn a
+fixed-length array into a dynamically sized array, by using the `len` field
+later on to define the `data` field's annotation:
+
+```
+DArray (a : Type) = Record {
+    len : I32,
+    data : Box (Array len a),
+}
 ```

--- a/src/semantics/errors.rs
+++ b/src/semantics/errors.rs
@@ -111,6 +111,14 @@ pub enum TypeError {
     },
     #[fail(display = "Undefined name `{}`", name)]
     UndefinedName { var_span: ByteSpan, name: Name },
+    #[fail(display = "Label mismatch: found label `{}` but `{}` was expected", found, expected)]
+    LabelMismatch {
+        span: ByteSpan,
+        found: core::Label,
+        expected: core::Label,
+    },
+    #[fail(display = "Ambiguous record")]
+    AmbiguousRecord { span: ByteSpan },
     #[fail(display = "The type `{}` does not contain a field named `{}`.", found, expected_label)]
     NoFieldInType {
         label_span: ByteSpan,
@@ -210,6 +218,16 @@ impl TypeError {
                     Label::new_primary(var_span).with_message("not found in this scope"),
                 )
             },
+            TypeError::LabelMismatch {
+                span,
+                ref expected,
+                ref found,
+            } => Diagnostic::new_error(format!(
+                "expected field called `{}`, but found a field called `{}",
+                expected, found,
+            )).with_label(Label::new_primary(span)),
+            TypeError::AmbiguousRecord { span } => Diagnostic::new_error("ambiguous record")
+                .with_label(Label::new_primary(span).with_message("type annotations needed here")),
             TypeError::NoFieldInType {
                 label_span,
                 ref expected_label,

--- a/src/semantics/tests/check.rs
+++ b/src/semantics/tests/check.rs
@@ -5,8 +5,32 @@ fn record() {
     let mut codemap = CodeMap::new();
     let context = Context::default();
 
-    let expected_ty = r"Record { x : F32, y : F32 }";
-    let given_expr = r"record { x = 3.0, y = 3.0 }";
+    let expected_ty = r"Record { t : Type, x : String }";
+    let given_expr = r#"record { t = String, x = "hello" }"#;
+
+    let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
+    parse_check(&mut codemap, &context, given_expr, &expected_ty);
+}
+
+#[test]
+fn dependent_record() {
+    let mut codemap = CodeMap::new();
+    let context = Context::default();
+
+    let expected_ty = r"Record { t : Type, x : t }";
+    let given_expr = r#"record { t = String, x = "hello" }"#;
+
+    let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
+    parse_check(&mut codemap, &context, given_expr, &expected_ty);
+}
+
+#[test]
+fn dependent_record_propagate_types() {
+    let mut codemap = CodeMap::new();
+    let context = Context::default();
+
+    let expected_ty = r"Record { t : Type, x : t }";
+    let given_expr = r#"record { t = I32, x = 1 }"#;
 
     let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
     parse_check(&mut codemap, &context, given_expr, &expected_ty);

--- a/src/semantics/tests/infer.rs
+++ b/src/semantics/tests/infer.rs
@@ -468,13 +468,13 @@ fn proj_weird() {
 
     let expected_ty = r"Type 1";
     let given_expr = r"Record {
-            Array : U16 -> Type -> Type,
-            t : Record { n : U16, x : Array n I8, y : Array n I8 },
-            inner-prod : (len : U16) -> Array len I8 -> Array len I8 -> I32,
+        Array : U16 -> Type -> Type,
+        t : Record { n : U16, x : Array n I8, y : Array n I8 },
+        inner-prod : (len : U16) -> Array len I8 -> Array len I8 -> I32,
 
-            test1 : I32 -> Type,
-            test2 : test1 (inner-prod t.n t.x t.y),
-        }";
+        test1 : I32 -> Type,
+        test2 : test1 (inner-prod t.n t.x t.y),
+    }";
 
     assert_term_eq!(
         parse_infer(&mut codemap, &context, given_expr).1,

--- a/src/syntax/core.rs
+++ b/src/syntax/core.rs
@@ -424,8 +424,8 @@ impl Term {
 
 /// Values
 ///
-/// These are either in _weak head normal form_ (they cannot be reduced further)
-/// or are _neutral terms_ (there is a possibility of reducing further depending
+/// These are either in _normal form_ (they cannot be reduced further) or are
+/// _neutral terms_ (there is a possibility of reducing further depending
 /// on the bindings given in the context)
 #[derive(Debug, Clone, PartialEq, BoundTerm)]
 pub enum Value {

--- a/src/syntax/pretty/core.rs
+++ b/src/syntax/pretty/core.rs
@@ -172,25 +172,24 @@ impl ToDoc for RawTerm {
             RawTerm::If(_, ref cond, ref if_true, ref if_false) => {
                 pretty_if(cond, if_true, if_false)
             },
-            RawTerm::RecordType(_, ref label, ref ann, ref rest) => {
+            RawTerm::RecordType(_, ref scope) => {
                 let mut inner = Doc::nil();
-                let mut label = label;
-                let mut ann = ann;
-                let mut rest = rest;
+                let mut scope = scope;
 
-                loop {
-                    inner = inner.append(
-                        parens(Doc::as_string(&label.0))
-                            .append(Doc::space())
-                            .append(ann.to_doc()),
-                    );
+                for i in 0.. {
+                    inner = inner
+                        .append(match i {
+                            0 => Doc::nil(),
+                            _ => Doc::space(),
+                        })
+                        .append(parens(
+                            Doc::as_string(&(scope.unsafe_pattern.0).0)
+                                .append(Doc::space())
+                                .append((scope.unsafe_pattern.1).0.to_doc()),
+                        ));
 
-                    match **rest {
-                        RawTerm::RecordType(_, ref next_label, ref next_ann, ref next_rest) => {
-                            label = next_label;
-                            ann = next_ann;
-                            rest = next_rest;
-                        },
+                    match *scope.unsafe_body {
+                        RawTerm::RecordType(_, ref next_scope) => scope = next_scope,
                         RawTerm::EmptyRecordType(_) => break,
                         _ => panic!("ill-formed record"),
                     }
@@ -198,25 +197,24 @@ impl ToDoc for RawTerm {
 
                 pretty_record_ty(inner)
             },
-            RawTerm::Record(_, ref label, ref expr, ref rest) => {
+            RawTerm::Record(_, ref scope) => {
                 let mut inner = Doc::nil();
-                let mut label = label;
-                let mut expr = expr;
-                let mut rest = rest;
+                let mut scope = scope;
 
-                loop {
-                    inner = inner.append(
-                        parens(Doc::as_string(&label.0))
-                            .append(Doc::space())
-                            .append(expr.to_doc()),
-                    );
+                for i in 0.. {
+                    inner = inner
+                        .append(match i {
+                            0 => Doc::nil(),
+                            _ => Doc::space(),
+                        })
+                        .append(parens(
+                            Doc::as_string(&(scope.unsafe_pattern.0).0)
+                                .append(Doc::space())
+                                .append((scope.unsafe_pattern.1).0.to_doc()),
+                        ));
 
-                    match **rest {
-                        RawTerm::Record(_, ref next_label, ref next_expr, ref next_rest) => {
-                            label = next_label;
-                            expr = next_expr;
-                            rest = next_rest;
-                        },
+                    match *scope.unsafe_body {
+                        RawTerm::Record(_, ref next_scope) => scope = next_scope,
                         RawTerm::EmptyRecord(_) => break,
                         _ => panic!("ill-formed record"),
                     }
@@ -250,25 +248,24 @@ impl ToDoc for Term {
             ),
             Term::App(ref f, ref a) => pretty_app(f, a),
             Term::If(_, ref cond, ref if_true, ref if_false) => pretty_if(cond, if_true, if_false),
-            Term::RecordType(_, ref label, ref ann, ref rest) => {
+            Term::RecordType(_, ref scope) => {
                 let mut inner = Doc::nil();
-                let mut label = label;
-                let mut ann = ann;
-                let mut rest = rest;
+                let mut scope = scope;
 
-                loop {
-                    inner = inner.append(
-                        parens(Doc::as_string(&label.0))
-                            .append(Doc::space())
-                            .append(ann.to_doc()),
-                    );
+                for i in 0.. {
+                    inner = inner
+                        .append(match i {
+                            0 => Doc::nil(),
+                            _ => Doc::space(),
+                        })
+                        .append(parens(
+                            Doc::as_string(&(scope.unsafe_pattern.0).0)
+                                .append(Doc::space())
+                                .append((scope.unsafe_pattern.1).0.to_doc()),
+                        ));
 
-                    match **rest {
-                        Term::RecordType(_, ref next_label, ref next_ann, ref next_rest) => {
-                            label = next_label;
-                            ann = next_ann;
-                            rest = next_rest;
-                        },
+                    match *scope.unsafe_body {
+                        Term::RecordType(_, ref next_scope) => scope = next_scope,
                         Term::EmptyRecordType(_) => break,
                         _ => panic!("ill-formed record"),
                     }
@@ -276,25 +273,24 @@ impl ToDoc for Term {
 
                 pretty_record_ty(inner)
             },
-            Term::Record(_, ref label, ref expr, ref rest) => {
+            Term::Record(_, ref scope) => {
                 let mut inner = Doc::nil();
-                let mut label = label;
-                let mut expr = expr;
-                let mut rest = rest;
+                let mut scope = scope;
 
-                loop {
-                    inner = inner.append(
-                        parens(Doc::as_string(&label.0))
-                            .append(Doc::space())
-                            .append(expr.to_doc()),
-                    );
+                for i in 0.. {
+                    inner = inner
+                        .append(match i {
+                            0 => Doc::nil(),
+                            _ => Doc::space(),
+                        })
+                        .append(parens(
+                            Doc::as_string(&(scope.unsafe_pattern.0).0)
+                                .append(Doc::space())
+                                .append((scope.unsafe_pattern.1).0.to_doc()),
+                        ));
 
-                    match **rest {
-                        Term::Record(_, ref next_label, ref next_expr, ref next_rest) => {
-                            label = next_label;
-                            expr = next_expr;
-                            rest = next_rest;
-                        },
+                    match *scope.unsafe_body {
+                        Term::Record(_, ref next_scope) => scope = next_scope,
                         Term::EmptyRecord(_) => break,
                         _ => panic!("ill-formed record"),
                     }
@@ -324,25 +320,24 @@ impl ToDoc for Value {
                 &(scope.unsafe_pattern.1).0,
                 &scope.unsafe_body,
             ),
-            Value::RecordType(ref label, ref ann, ref rest) => {
+            Value::RecordType(ref scope) => {
                 let mut inner = Doc::nil();
-                let mut label = label;
-                let mut ann = ann;
-                let mut rest = rest;
+                let mut scope = scope;
 
-                loop {
-                    inner = inner.append(
-                        parens(Doc::as_string(&label.0))
-                            .append(Doc::space())
-                            .append(ann.to_doc()),
-                    );
+                for i in 0.. {
+                    inner = inner
+                        .append(match i {
+                            0 => Doc::nil(),
+                            _ => Doc::space(),
+                        })
+                        .append(parens(
+                            Doc::as_string(&(scope.unsafe_pattern.0).0)
+                                .append(Doc::space())
+                                .append((scope.unsafe_pattern.1).0.to_doc()),
+                        ));
 
-                    match **rest {
-                        Value::RecordType(ref next_label, ref next_ann, ref next_rest) => {
-                            label = next_label;
-                            ann = next_ann;
-                            rest = next_rest;
-                        },
+                    match *scope.unsafe_body {
+                        Value::RecordType(ref next_scope) => scope = next_scope,
                         Value::EmptyRecordType => break,
                         _ => panic!("ill-formed record"),
                     }
@@ -350,25 +345,24 @@ impl ToDoc for Value {
 
                 pretty_record_ty(inner)
             },
-            Value::Record(ref label, ref expr, ref rest) => {
+            Value::Record(ref scope) => {
                 let mut inner = Doc::nil();
-                let mut label = label;
-                let mut expr = expr;
-                let mut rest = rest;
+                let mut scope = scope;
 
-                loop {
-                    inner = inner.append(
-                        parens(Doc::as_string(&label.0))
-                            .append(Doc::space())
-                            .append(expr.to_doc()),
-                    );
+                for i in 0.. {
+                    inner = inner
+                        .append(match i {
+                            0 => Doc::nil(),
+                            _ => Doc::space(),
+                        })
+                        .append(parens(
+                            Doc::as_string(&(scope.unsafe_pattern.0).0)
+                                .append(Doc::space())
+                                .append((scope.unsafe_pattern.1).0.to_doc()),
+                        ));
 
-                    match **rest {
-                        Value::Record(ref next_label, ref next_expr, ref next_rest) => {
-                            label = next_label;
-                            expr = next_expr;
-                            rest = next_rest;
-                        },
+                    match *scope.unsafe_body {
+                        Value::Record(ref next_scope) => scope = next_scope,
                         Value::EmptyRecord => break,
                         _ => panic!("ill-formed record"),
                     }

--- a/src/syntax/translation/desugar/mod.rs
+++ b/src/syntax/translation/desugar/mod.rs
@@ -101,9 +101,13 @@ fn desugar_record_ty(
     for &(start, ref label, ref ann) in fields.iter().rev() {
         term = core::RawTerm::RecordType(
             Ignore(ByteSpan::new(start, term.span().end())),
-            core::Label(label.clone()),
-            Rc::new(ann.desugar()),
-            Rc::new(term),
+            nameless::bind(
+                (
+                    core::Label(Name::user(label.clone())),
+                    Embed(Rc::new(ann.desugar())),
+                ),
+                Rc::new(term),
+            ),
         );
     }
 
@@ -119,9 +123,13 @@ fn desugar_record(
     for &(start, ref label, ref value) in fields.iter().rev() {
         term = core::RawTerm::Record(
             Ignore(ByteSpan::new(start, term.span().end())),
-            core::Label(label.clone()),
-            Rc::new(value.desugar()),
-            Rc::new(term),
+            nameless::bind(
+                (
+                    core::Label(Name::user(label.clone())),
+                    Embed(Rc::new(value.desugar())),
+                ),
+                Rc::new(term),
+            ),
         );
     }
 
@@ -273,7 +281,7 @@ impl Desugar<core::RawTerm> for concrete::Term {
                     span,
                     Rc::new(tm.desugar()),
                     label_span,
-                    core::Label(label.clone()),
+                    core::Label(Name::user(label.clone())),
                 )
             },
             concrete::Term::Error(_) => unimplemented!("error recovery"),

--- a/src/syntax/translation/resugar.rs
+++ b/src/syntax/translation/resugar.rs
@@ -365,25 +365,21 @@ impl Resugar<concrete::Term> for core::Term {
                     Box::new(if_false.resugar_prec(Prec::APP)),
                 ),
             ),
-            core::Term::RecordType(_, ref label, ref ann, ref rest) => {
+            core::Term::RecordType(_, ref scope) => {
                 let mut fields = vec![];
-                let mut label = label;
-                let mut ann = ann;
-                let mut rest = rest;
+                let mut scope = scope.clone();
 
                 loop {
+                    let ((label, Embed(expr)), body) = nameless::unbind(scope);
+
                     fields.push((
                         ByteIndex::default(),
-                        label.0.clone(),
-                        Box::new(ann.resugar_prec(Prec::NO_WRAP)),
+                        label.0.to_string(),
+                        Box::new(expr.resugar_prec(Prec::NO_WRAP)),
                     ));
 
-                    match **rest {
-                        core::Term::RecordType(_, ref next_label, ref next_ann, ref next_rest) => {
-                            label = next_label;
-                            ann = next_ann;
-                            rest = next_rest;
-                        },
+                    match *body {
+                        core::Term::RecordType(_, ref next_scope) => scope = next_scope.clone(),
                         core::Term::EmptyRecordType(_) => break,
                         _ => panic!("ill-formed record type"), // FIXME: better error
                     }
@@ -391,25 +387,21 @@ impl Resugar<concrete::Term> for core::Term {
 
                 concrete::Term::RecordType(ByteSpan::default(), fields)
             },
-            core::Term::Record(_, ref label, ref expr, ref rest) => {
+            core::Term::Record(_, ref scope) => {
                 let mut fields = vec![];
-                let mut label = label;
-                let mut expr = expr;
-                let mut rest = rest;
+                let mut scope = scope.clone();
 
                 loop {
+                    let ((label, Embed(expr)), body) = nameless::unbind(scope);
+
                     fields.push((
                         ByteIndex::default(),
-                        label.0.clone(),
+                        label.0.to_string(),
                         Box::new(expr.resugar_prec(Prec::NO_WRAP)),
                     ));
 
-                    match **rest {
-                        core::Term::Record(_, ref next_label, ref next_expr, ref next_rest) => {
-                            label = next_label;
-                            expr = next_expr;
-                            rest = next_rest;
-                        },
+                    match *body {
+                        core::Term::Record(_, ref next_scope) => scope = next_scope.clone(),
                         core::Term::EmptyRecord(_) => break,
                         _ => panic!("ill-formed record"), // FIXME: better error
                     }
@@ -424,7 +416,7 @@ impl Resugar<concrete::Term> for core::Term {
             core::Term::Proj(_, ref expr, _, ref label) => concrete::Term::Proj(
                 Box::new(expr.resugar_prec(Prec::ATOMIC)),
                 ByteIndex::default(),
-                label.0.clone(),
+                label.0.to_string(),
             ),
         }
     }


### PR DESCRIPTION
This PR builds atop #45, allowing the fields of record types to depend on the values of previous fields. This is important for allowing us to use records as modules.

Fixes #2.