### PR TITLE
Add booleans as primitive types and implement if expressions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ codespan = "0.1.1"
 codespan-reporting = "0.1.1"
 failure = "0.1.1"
 lalrpop-util = "0.15.1"
-nameless = { git = "https://github.com/brendanzab/nameless", rev = "147029a", version = "0.1.0" }
+nameless = { git = "https://github.com/brendanzab/nameless", rev = "30121a6", version = "0.1.0" }
 pretty = "0.3.2"
 regex = "0.2.0"
 rpds = "0.4.0"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -4,6 +4,7 @@
 
 - [Installation](./installation/index.md)
 - [Language](./language/index.md)
+  - [Conditionals](./language/conditionals.md)
   - [Records](./language/records.md)
   - [Functions](./language/functions.md)
   - [Type inference](./language/type-inference.md)

--- a/book/src/appendix/theory.md
+++ b/book/src/appendix/theory.md
@@ -62,28 +62,33 @@ TODO: describe BNF syntax and natural deduction here
 \\newcommand{\ntype}{N}
 \\
 % Term and Type constructors
-\\newcommand{\const}{c}
 \\newcommand{\Type}{\mathsf{Type}}
+\\newcommand{\Bool}{\mathsf{Bool}}
+\\newcommand{\true}{\mathsf{true}}
+\\newcommand{\false}{\mathsf{false}}
 \\newcommand{\Arrow}[2]{ #1 \rightarrow #2 }
 \\newcommand{\Pi}[2]{ \Arrow{(#1)}{#2} }
 \\newcommand{\lam}[2]{ \lambda #1 . #2 }
+\\newcommand{\ifte}[3]{ \text{if} ~ #1 ~ \text{then} ~ #2 ~ \text{else} ~ #3 }
 \\newcommand{\Record}[1]{ ( #1 ) }
 \\newcommand{\record}[1]{ \langle #1 \rangle }
 \\
 \begin{array}{rrll}
-    \rexpr,\rtype   & ::= & x                               & \text{variables} \\\\
-                    &   | & \Type_i                         & \text{universe of types ($i \in \mathbb{N}$)} \\\\
-                    &   | & ?                               & \text{holes} \\\\
-                    &   | & \const                          & \text{constants} \\\\
-                    &   | & \rexpr : \rtype                 & \text{term annotated with a type} \\\\
-                    &   | & \Pi{x:\rtype_1}{\rtype_2}       & \text{dependent function type} \\\\
-                    &   | & \lam{x:\rtype}{\rexpr}          & \text{functions} \\\\
-                    &   | & \rexpr_1 ~ \rexpr_2             & \text{function application} \\\\
-                    &   | & \Record{l:\rtype_1, \rtype_2}   & \text{record type extension} \\\\
-                    &   | & \Record{}                       & \text{empty record type} \\\\
-                    &   | & \record{l=\rexpr_1, \rexpr_2}   & \text{record extension} \\\\
-                    &   | & \record{}                       & \text{empty record} \\\\
-                    &   | & \rexpr.l                        & \text{record projection} \\\\
+    \rexpr,\rtype   & ::= & x                                   & \text{variables} \\\\
+                    &   | & \Type_i                             & \text{universe of types ($i \in \mathbb{N}$)} \\\\
+                    &   | & ?                                   & \text{holes} \\\\
+                    &   | & \Bool                               & \text{type of booleans} \\\\
+                    &   | & \true ~|~ \false                    & \text{boolean values} \\\\
+                    &   | & \rexpr : \rtype                     & \text{term annotated with a type} \\\\
+                    &   | & \Pi{x:\rtype_1}{\rtype_2}           & \text{dependent function type} \\\\
+                    &   | & \lam{x:\rtype}{\rexpr}              & \text{functions} \\\\
+                    &   | & \rexpr_1 ~ \rexpr_2                 & \text{function application} \\\\
+                    &   | & \ifte{\rexpr_1}{\rexpr_2}{\rexpr_3} & \text{if expressions} \\\\
+                    &   | & \Record{l:\rtype_1, \rtype_2}       & \text{record type extension} \\\\
+                    &   | & \Record{}                           & \text{empty record type} \\\\
+                    &   | & \record{l=\rexpr_1, \rexpr_2}       & \text{record extension} \\\\
+                    &   | & \record{}                           & \text{empty record} \\\\
+                    &   | & \rexpr.l                            & \text{record projection} \\\\
     \\\\
 \end{array}
 \\]
@@ -101,18 +106,20 @@ The core term syntax skips holes, ensuring that everything is fully elaborated:
 
 \\[
 \begin{array}{rrll}
-    \texpr,\ttype   & ::= & x                               & \text{variables} \\\\
-                    &   | & \Type_i                         & \text{universe of types ($i \in \mathbb{N}$)} \\\\
-                    &   | & \const                          & \text{constants} \\\\
-                    &   | & \texpr : \ttype                 & \text{term annotated with a type} \\\\
-                    &   | & \Pi{x:\ttype_1}{\ttype_2}       & \text{dependent function type} \\\\
-                    &   | & \lam{x:\ttype}{\texpr}          & \text{functions} \\\\
-                    &   | & \texpr_1 ~ \texpr_2             & \text{function application} \\\\
-                    &   | & \Record{l:\ttype_1, \ttype_2}   & \text{record type extension} \\\\
-                    &   | & \Record{}                       & \text{empty record type} \\\\
-                    &   | & \record{l=\texpr_1, \texpr_2}   & \text{record extension} \\\\
-                    &   | & \record{}                       & \text{empty record} \\\\
-                    &   | & \texpr.l                        & \text{record projection} \\\\
+    \texpr,\ttype   & ::= & x                                   & \text{variables} \\\\
+                    &   | & \Type_i                             & \text{universe of types ($i \in \mathbb{N}$)} \\\\
+                    &   | & \Bool                               & \text{type of booleans} \\\\
+                    &   | & \true ~|~ \false                    & \text{boolean values} \\\\
+                    &   | & \texpr : \ttype                     & \text{term annotated with a type} \\\\
+                    &   | & \Pi{x:\ttype_1}{\ttype_2}           & \text{dependent function type} \\\\
+                    &   | & \lam{x:\ttype}{\texpr}              & \text{functions} \\\\
+                    &   | & \texpr_1 ~ \texpr_2                 & \text{function application} \\\\
+                    &   | & \ifte{\texpr_1}{\texpr_2}{\texpr_3} & \text{if expressions} \\\\
+                    &   | & \Record{l:\ttype_1, \ttype_2}       & \text{record type extension} \\\\
+                    &   | & \Record{}                           & \text{empty record type} \\\\
+                    &   | & \record{l=\texpr_1, \texpr_2}       & \text{record extension} \\\\
+                    &   | & \record{}                           & \text{empty record} \\\\
+                    &   | & \texpr.l                            & \text{record projection} \\\\
     \\\\
 \end{array}
 \\]
@@ -125,21 +132,23 @@ and neutral terms (\\(\nexpr\\)):
 
 \\[
 \begin{array}{rrll}
-    \vexpr,\vtype   & ::= & \wexpr                          & \text{weak head normal forms} \\\\
-                    &   | & \nexpr                          & \text{neutral terms} \\\\
+    \vexpr,\vtype   & ::= & \wexpr                              & \text{weak head normal forms} \\\\
+                    &   | & \nexpr                              & \text{neutral terms} \\\\
     \\\\
-    \nexpr,\ntype   & ::= & x                               & \text{variables} \\\\
-                    &   | & \nexpr ~ \texpr                 & \text{function application} \\\\
-                    &   | & \nexpr.l                        & \text{record projection} \\\\
+    \nexpr,\ntype   & ::= & x                                   & \text{variables} \\\\
+                    &   | & \nexpr ~ \texpr                     & \text{function application} \\\\
+                    &   | & \ifte{\nexpr_1}{\texpr_2}{\texpr_3} & \text{if expressions} \\\\
+                    &   | & \nexpr.l                            & \text{record projection} \\\\
     \\\\
-    \wexpr,\wtype   & ::= & \Type_i                         & \text{universe of types ($i \in \mathbb{N}$)} \\\\
-                    &   | & \const                          & \text{constants} \\\\
-                    &   | & \Pi{x:\vtype_1}{\vtype_2}       & \text{dependent function type} \\\\
-                    &   | & \lam{x:\vtype}{\vexpr}          & \text{functions} \\\\
-                    &   | & \Record{l:\vtype_1, \vtype_2}   & \text{record type extension} \\\\
-                    &   | & \Record{}                       & \text{empty record type} \\\\
-                    &   | & \record{l=\vexpr_1, \vexpr_2}   & \text{record extension} \\\\
-                    &   | & \record{}                       & \text{empty record} \\\\
+    \wexpr,\wtype   & ::= & \Type_i                             & \text{universe of types ($i \in \mathbb{N}$)} \\\\
+                    &   | & \Bool                               & \text{type of booleans} \\\\
+                    &   | & \true ~|~ \false                    & \text{boolean values} \\\\
+                    &   | & \Pi{x:\vtype_1}{\vtype_2}           & \text{dependent function type} \\\\
+                    &   | & \lam{x:\vtype}{\vexpr}              & \text{functions} \\\\
+                    &   | & \Record{l:\vtype_1, \vtype_2}       & \text{record type extension} \\\\
+                    &   | & \Record{}                           & \text{empty record type} \\\\
+                    &   | & \record{l=\vexpr_1, \vexpr_2}       & \text{record extension} \\\\
+                    &   | & \record{}                           & \text{empty record} \\\\
     \\\\
 \end{array}
 \\]
@@ -236,8 +245,16 @@ in the context.
         \eval{ \Gamma }{ \Type_i }{ \Type_i }
     }
     \\\\[2em]
-    \rule{E-CONST}{}{
-        \eval{ \Gamma }{ \const }{ \const }
+    \rule{E-BOOL}{}{
+        \eval{ \Gamma }{ \Bool }{ \Bool }
+    }
+    \\\\[2em]
+    \rule{E-TRUE}{}{
+        \eval{ \Gamma }{ \true }{ \true }
+    }
+    \\\\[2em]
+    \rule{E-FALSE}{}{
+        \eval{ \Gamma }{ \false }{ \false }
     }
     \\\\[2em]
     \rule{E-VAR}{
@@ -278,6 +295,28 @@ in the context.
         \eval{ \Gamma, x=\vexpr_2 }{ \vexpr_1 }{ \vexpr_3 }
     }{
         \eval{ \Gamma }{ \texpr_1 ~ \texpr_2 }{ \vexpr_3 }
+    }
+    \\\\[2em]
+    \rule{E-IF}{
+        \eval{ \Gamma }{ \nexpr }{ \nexpr' }
+    }{
+        \eval{ \Gamma }{ \ifte{\nexpr}{\texpr_1}{\texpr_2} }{ \ifte{\nexpr'}{\texpr_1}{\texpr_2} }
+    }
+    \\\\[2em]
+    \rule{E-IF-TRUE}{
+        \eval{ \Gamma }{ \nexpr }{ \true }
+        \qquad
+        \eval{ \Gamma }{ \texpr_1 }{ \vexpr_1 }
+    }{
+        \eval{ \Gamma }{ \ifte{\nexpr}{\texpr_1}{\texpr_2} }{ \vexpr_1 }
+    }
+    \\\\[2em]
+    \rule{E-IF-FALSE}{
+        \eval{ \Gamma }{ \nexpr }{ \false }
+        \qquad
+        \eval{ \Gamma }{ \texpr_2 }{ \vexpr_2 }
+    }{
+        \eval{ \Gamma }{ \ifte{\nexpr}{\texpr_1}{\texpr_2} }{ \vexpr_2 }
     }
     \\\\[2em]
     \rule{E-RECORD-TYPE}{
@@ -341,6 +380,16 @@ elaborated form.
         \check{ \Gamma }{ \lam{x}{\rexpr} }{ \Pi{x:\vtype_1}{\vtype_2} }{ \lam{x:\vtype_1}{\texpr} }
     }
     \\\\[2em]
+    \rule{C-IF}{
+        \check{ \Gamma }{ \rexpr_1 }{ \Bool }{ \texpr_1 }
+        \qquad
+        \check{ \Gamma }{ \rexpr_2 }{ \vtype }{ \texpr_2 }
+        \qquad
+        \check{ \Gamma }{ \rexpr_3 }{ \vtype }{ \texpr_3 }
+    }{
+        \check{ \Gamma }{ \ifte{\rexpr_1}{\rexpr_2}{\rexpr_3} }{ \vtype }{ \ifte{\texpr_1}{\texpr_2}{\texpr_3} }
+    }
+    \\\\[2em]
     \rule{C-RECORD}{
         l_1 \equiv l_2
         \qquad
@@ -392,6 +441,18 @@ returns its elaborated form.
     \\\\[2em]
     \rule{I-TYPE}{}{
         \infer{ \Gamma }{ \Type_i }{ \Type_{i+1} }{ \Type_i }
+    }
+    \\\\[2em]
+    \rule{I-BOOL}{}{
+        \infer{ \Gamma }{ \Bool }{ \Type_0 }{ \Bool }
+    }
+    \\\\[2em]
+    \rule{I-TRUE}{}{
+        \infer{ \Gamma }{ \true }{ \Bool }{ \true }
+    }
+    \\\\[2em]
+    \rule{I-FALSE}{}{
+        \infer{ \Gamma }{ \false }{ \Bool }{ \false }
     }
     \\\\[2em]
     \rule{I-VAR}{

--- a/book/src/language/conditionals.md
+++ b/book/src/language/conditionals.md
@@ -1,0 +1,16 @@
+# Conditionals
+
+## If-then-else expressions
+
+If expressions take an expression that evaluates to a `Bool` (the _condition_),
+and two other expressions (the _consequent_ and the _alternative_) that evaluate
+to the same type. If the condition evaluates to `true`, then the consequent will
+be evaluated and returned, otherwise the alternative will be evaluated and
+returned.
+
+```pikelet-repl
+Pikelet> if true then "hello!" else "goodbye!"
+"hello!" : String
+Pikelet> if false then "hello!" else "goodbye!"
+"goodbye!" : String
+```

--- a/book/src/language/index.md
+++ b/book/src/language/index.md
@@ -63,6 +63,7 @@ Pikelet has a number of primitive types:
 
 | Type     | Literal                                |
 |----------|----------------------------------------|
+| `Bool`   | `true`, `false`                        |
 | `String` | `"hello there!"`                       |
 | `Char`   | `'a'`, `'b'`, ..., `'\n'`, `'\t'`, ... |
 | `U8`     | `1`, `2`, `3`, ...                     |

--- a/book/src/language/type-inference.md
+++ b/book/src/language/type-inference.md
@@ -36,8 +36,10 @@ Inferrable terms can be checked on their own or based on previous definitions.
 > TODO: Explain examples
 
 ```pikelet-repl
+Pikelet> true
 Pikelet> "1"
 Pikelet> 'a'
+Pikelet> Bool
 Pikelet> Type
 Pikelet> Type 2
 Pikelet> record { name = "Jane" }

--- a/src/library/prelude.pi
+++ b/src/library/prelude.pi
@@ -37,13 +37,13 @@ flip a b c f x y = f y x;
 |||
 ||| This type should have no inhabitants - if it does, it's a bug in our
 ||| typechecker!
-false : Type 1;
-false = (a : Type) -> a;
+void : Type 1;
+void = (a : Type) -> a;
 
 
 ||| Logical negation
 not : Type -> Type 1;
-not a = a -> false;
+not a = a -> void;
 
 
 unit : Type 1;
@@ -90,3 +90,22 @@ or p q = (c : Type) -> (p -> c) -> (q -> c) -> c;
 
 -- or-intro-right : (p q : Type) -> q -> or p q;
 -- or-intro-right p q (y : q) c (on-p : p -> c) (on-q : q -> c) = on-q y;
+
+
+||| Module for defining equality between two terms
+Eq (a : Type) = Record {
+    ||| Compare two terms for equality
+    eq : a -> a -> Bool,
+};
+
+||| Compare two terms for equality
+eq : (a : Type) (EQ : Eq a) -> a -> a -> Bool;
+eq a EQ = EQ.eq;
+
+
+Eq-Bool : Eq Bool;
+Eq-Bool = record {
+    eq = \lhs rhs =>
+        if lhs then rhs else
+            (if rhs then false else true),
+};

--- a/src/semantics/errors.rs
+++ b/src/semantics/errors.rs
@@ -18,6 +18,8 @@ pub enum InternalError {
     },
     #[fail(display = "Argument applied to non-function.")]
     ArgumentAppliedToNonFunction { span: ByteSpan },
+    #[fail(display = "Expected a boolean expression.")]
+    ExpectedBoolExpr { span: ByteSpan },
     #[fail(display = "Projected on non-existent field `{}`.", label)]
     ProjectedOnNonExistentField {
         label_span: ByteSpan,
@@ -28,8 +30,9 @@ pub enum InternalError {
 impl InternalError {
     pub fn span(&self) -> ByteSpan {
         match *self {
-            InternalError::UnsubstitutedDebruijnIndex { span, .. } => span,
-            InternalError::ArgumentAppliedToNonFunction { span, .. } => span,
+            InternalError::UnsubstitutedDebruijnIndex { span, .. }
+            | InternalError::ArgumentAppliedToNonFunction { span, .. }
+            | InternalError::ExpectedBoolExpr { span, .. } => span,
             InternalError::ProjectedOnNonExistentField { label_span, .. } => label_span,
         }
     }
@@ -45,6 +48,11 @@ impl InternalError {
             InternalError::ArgumentAppliedToNonFunction { span } => {
                 Diagnostic::new_bug(format!("argument applied to non-function"))
                     .with_label(Label::new_primary(span).with_message("not a function"))
+            },
+            InternalError::ExpectedBoolExpr { span } => {
+                Diagnostic::new_bug(format!("expected a boolean expression")).with_label(
+                    Label::new_primary(span).with_message("did not evaluate to a boolean"),
+                )
             },
             InternalError::ProjectedOnNonExistentField {
                 label_span,

--- a/src/semantics/mod.rs
+++ b/src/semantics/mod.rs
@@ -20,7 +20,7 @@ pub use self::errors::{InternalError, TypeError};
 
 /// Typecheck and elaborate a module
 pub fn check_module(raw_module: &RawModule) -> Result<Module, TypeError> {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let mut definitions = Vec::with_capacity(raw_module.definitions.len());
 
     for raw_definition in &raw_module.definitions {

--- a/src/syntax/concrete.rs
+++ b/src/syntax/concrete.rs
@@ -211,7 +211,7 @@ pub enum Term {
     /// Type
     /// ```
     Universe(ByteSpan, Option<u32>),
-    /// Literal values
+    /// Literal value
     Literal(ByteSpan, Literal),
     /// Holes
     ///
@@ -219,13 +219,13 @@ pub enum Term {
     /// _
     /// ```
     Hole(ByteSpan),
-    /// Variables
+    /// Variable
     ///
     /// ```text
     /// x
     /// ```
     Var(ByteIndex, String),
-    /// Lambda abstractions
+    /// Lambda abstraction
     ///
     /// ```text
     /// \x => t
@@ -235,14 +235,14 @@ pub enum Term {
     /// \(x y : t1) => t3
     /// ```
     Lam(ByteIndex, LamParams, Box<Term>),
-    /// Dependent function types
+    /// Dependent function type
     ///
     /// ```text
     /// (x : t1) -> t2
     /// (x y : t1) -> t2
     /// ```
     Pi(ByteIndex, PiParams, Box<Term>),
-    /// Non-Dependent function types
+    /// Non-Dependent function type
     ///
     /// ```text
     /// t1 -> t2
@@ -263,13 +263,19 @@ pub enum Term {
     ///     x
     /// ```
     Let(ByteIndex, Vec<Declaration>, Box<Term>),
-    /// Record types
+    /// If expression
+    ///
+    /// ```text
+    /// if t1 then t2 else t3
+    /// ```
+    If(ByteIndex, Box<Term>, Box<Term>, Box<Term>),
+    /// Record type
     ///
     /// ```text
     /// Record { x : t1, .. }
     /// ```
     RecordType(ByteSpan, Vec<(ByteIndex, String, Box<Term>)>),
-    /// Record values
+    /// Record value
     ///
     /// ```text
     /// record { x = t1, .. }
@@ -301,7 +307,8 @@ impl Term {
             Term::Var(start, ref name) => ByteSpan::from_offset(start, ByteOffset::from_str(name)),
             Term::Pi(start, _, ref body)
             | Term::Lam(start, _, ref body)
-            | Term::Let(start, _, ref body) => ByteSpan::new(start, body.span().end()),
+            | Term::Let(start, _, ref body)
+            | Term::If(start, _, _, ref body) => ByteSpan::new(start, body.span().end()),
             Term::Ann(ref term, ref ty) => term.span().to(ty.span()),
             Term::Arrow(ref ann, ref body) => ann.span().to(body.span()),
             Term::App(ref fn_term, ref arg) => fn_term.span().to(arg[arg.len() - 1].span()),

--- a/src/syntax/core.rs
+++ b/src/syntax/core.rs
@@ -55,6 +55,7 @@ impl fmt::Display for RawConstant {
 /// expensive computationally!
 #[derive(Debug, Clone, PartialEq, PartialOrd, BoundTerm)]
 pub enum Constant {
+    Bool(bool),
     String(String),
     Char(char),
     U8(u8),
@@ -67,6 +68,7 @@ pub enum Constant {
     I64(i64),
     F32(f32),
     F64(f64),
+    BoolType,
     StringType,
     CharType,
     U8Type,
@@ -619,8 +621,15 @@ impl Default for Context {
     fn default() -> Context {
         let universe0 = Rc::new(Value::Universe(Level(0)));
         let constant = |c| Rc::new(Term::Constant(Ignore::default(), c));
+        let constant_val = |c| Rc::new(Value::Constant(c));
 
         Context::new()
+            .claim(Name::user("true"), constant_val(Constant::BoolType))
+            .define(Name::user("true"), constant(Constant::Bool(true)))
+            .claim(Name::user("false"), constant_val(Constant::BoolType))
+            .define(Name::user("false"), constant(Constant::Bool(false)))
+            .claim(Name::user("Bool"), universe0.clone())
+            .define(Name::user("Bool"), constant(Constant::BoolType))
             .claim(Name::user("String"), universe0.clone())
             .define(Name::user("String"), constant(Constant::StringType))
             .claim(Name::user("Char"), universe0.clone())

--- a/src/syntax/parse/grammar.lalrpop
+++ b/src/syntax/parse/grammar.lalrpop
@@ -22,13 +22,16 @@ extern {
 
         // Keywords
         "as" => Token::As,
+        "else" => Token::Else,
         "_" => Token::Hole,
+        "if" => Token::If,
         "in" => Token::In,
         "let" => Token::Let,
         "module" => Token::Module,
         "import" => Token::Import,
         "record" => Token::Record,
         "Record" => Token::RecordType,
+        "then" => Token::Then,
         "Type" => Token::Type,
         "where" => Token::Where,
 
@@ -144,6 +147,9 @@ LamTerm: Term = {
     },
     <start: @L> "\\" <params: AtomicLamParam+> "=>" <body: LamTerm> => {
         Term::Lam(start, params, Box::new(body))
+    },
+    <start: @L> "if" <cond: AppTerm> "then" <if_true: AppTerm> "else" <if_false: AppTerm> => {
+        Term::If(start, Box::new(cond), Box::new(if_true), Box::new(if_false))
     },
     <start: @L> "let" <declarations: Declaration+> "in" <body: LamTerm> => {
         Term::Let(start, declarations, Box::new(body))

--- a/src/syntax/parse/grammar.lalrpop
+++ b/src/syntax/parse/grammar.lalrpop
@@ -101,8 +101,8 @@ Declaration: Declaration = {
     <_comment: "doc comment"*> <name: IndexedIdent> ":" <ann: Term> ";" => {
         Declaration::Claim { name, ann }
     },
-    <name: IndexedIdent> <params: AtomicLamParam*> "=" <body: Term>
-        <wheres: ("where" "{" <Declaration+> "}")?> <end: @R> ";" =>
+    <_comment: "doc comment"*> <name: IndexedIdent> <params: AtomicLamParam*> "="
+        <body: Term> <wheres: ("where" "{" <Declaration+> "}")?> <end: @R> ";" =>
     {
         let (start, name) = name;
         let span = ByteSpan::new(start, end);
@@ -221,7 +221,9 @@ AtomicLamParam: (Vec<(ByteIndex, String)>, Option<Box<Term>>) = {
 };
 
 RecordTypeField: (ByteIndex, String, Box<Term>) = {
-    <start: @L> <label: Ident> ":" <ty: Term> => (start, label, Box::new(ty)),
+    <_comment: "doc comment"*> <start: @L> <label: Ident> ":" <ty: Term> => {
+        (start, label, Box::new(ty))
+    },
 };
 
 RecordField: (ByteIndex, String, Box<Term>) = {

--- a/src/syntax/parse/lexer.rs
+++ b/src/syntax/parse/lexer.rs
@@ -106,13 +106,16 @@ pub enum Token<S> {
 
     // Keywords
     As,         // as
+    Else,       // else
     Hole,       // _
+    If,         // if
     In,         // in
     Let,        // let
     Module,     // module
     Import,     // import
     Record,     // record
     RecordType, // Record
+    Then,       // then
     Type,       // Type
     Where,      // where
 
@@ -147,13 +150,16 @@ impl<S: fmt::Display> fmt::Display for Token<S> {
             Token::DecLiteral(ref value) => write!(f, "{}", value),
             Token::FloatLiteral(ref value) => write!(f, "{}", value),
             Token::As => write!(f, "as"),
+            Token::Else => write!(f, "else"),
             Token::Hole => write!(f, "_"),
+            Token::If => write!(f, "if"),
             Token::In => write!(f, "in"),
             Token::Let => write!(f, "let"),
             Token::Module => write!(f, "module"),
             Token::Import => write!(f, "import"),
             Token::Record => write!(f, "record"),
             Token::RecordType => write!(f, "Record"),
+            Token::Then => write!(f, "then"),
             Token::Type => write!(f, "Type"),
             Token::Where => write!(f, "where"),
             Token::BSlash => write!(f, "\\"),
@@ -186,13 +192,16 @@ impl<'input> From<Token<&'input str>> for Token<String> {
             Token::DecLiteral(value) => Token::DecLiteral(value),
             Token::FloatLiteral(value) => Token::FloatLiteral(value),
             Token::As => Token::As,
+            Token::Else => Token::Else,
             Token::Hole => Token::Hole,
+            Token::If => Token::If,
             Token::In => Token::In,
             Token::Let => Token::Let,
             Token::Module => Token::Module,
             Token::Import => Token::Import,
             Token::Record => Token::Record,
             Token::RecordType => Token::RecordType,
+            Token::Then => Token::Then,
             Token::Type => Token::Type,
             Token::Where => Token::Where,
             Token::BSlash => Token::BSlash,
@@ -359,13 +368,16 @@ impl<'input> Lexer<'input> {
 
         let token = match ident {
             "as" => Token::As,
+            "else" => Token::Else,
             "_" => Token::Hole,
+            "if" => Token::If,
             "in" => Token::In,
             "let" => Token::Let,
             "module" => Token::Module,
             "import" => Token::Import,
             "record" => Token::Record,
             "Record" => Token::RecordType,
+            "then" => Token::Then,
             "Type" => Token::Type,
             "where" => Token::Where,
             ident => Token::Ident(ident),

--- a/src/syntax/pretty/concrete.rs
+++ b/src/syntax/pretty/concrete.rs
@@ -172,6 +172,17 @@ impl ToDoc for Term {
                     .append(Doc::text("in"))
                     .append(body.to_doc(options))
             },
+            Term::If(_, ref cond, ref if_true, ref if_false) => Doc::text("if")
+                .append(Doc::space())
+                .append(cond.to_doc(options))
+                .append(Doc::space())
+                .append(Doc::text("then"))
+                .append(Doc::space())
+                .append(if_true.to_doc(options))
+                .append(Doc::space())
+                .append(Doc::text("else"))
+                .append(Doc::space())
+                .append(if_false.to_doc(options)),
             Term::RecordType(_, ref fields) if fields.is_empty() => Doc::text("Record {}"),
             Term::Record(_, ref fields) if fields.is_empty() => Doc::text("record {}"),
             Term::RecordType(_, ref fields) => Doc::text("Record {")

--- a/src/syntax/pretty/core.rs
+++ b/src/syntax/pretty/core.rs
@@ -160,6 +160,8 @@ impl ToDoc for RawConstant {
 impl ToDoc for Constant {
     fn to_doc(&self, _options: Options) -> StaticDoc {
         match *self {
+            Constant::Bool(true) => Doc::text("#true"),
+            Constant::Bool(false) => Doc::text("#false"),
             Constant::String(ref value) => Doc::text(format!("{:?}", value)),
             Constant::Char(value) => Doc::text(format!("{:?}", value)),
             Constant::U8(value) => Doc::as_string(value),
@@ -172,6 +174,7 @@ impl ToDoc for Constant {
             Constant::I64(value) => Doc::as_string(value),
             Constant::F32(value) => Doc::as_string(value),
             Constant::F64(value) => Doc::as_string(value),
+            Constant::BoolType => Doc::text("#Bool"),
             Constant::StringType => Doc::text("#String"),
             Constant::CharType => Doc::text("#Char"),
             Constant::U8Type => Doc::text("#U8"),

--- a/src/syntax/pretty/core.rs
+++ b/src/syntax/pretty/core.rs
@@ -108,6 +108,28 @@ fn pretty_app<F: ToDoc, A: ToDoc>(options: Options, fn_term: &F, arg_term: &A) -
     )
 }
 
+fn pretty_if<C: ToDoc, T: ToDoc, F: ToDoc>(
+    options: Options,
+    cond: &C,
+    if_true: &T,
+    if_false: &F,
+) -> StaticDoc {
+    parens_if(
+        Prec::LAM < options.prec,
+        Doc::text("if")
+            .append(Doc::space())
+            .append(cond.to_doc(options.with_prec(Prec::APP)))
+            .append(Doc::space())
+            .append(Doc::text("then"))
+            .append(Doc::space())
+            .append(if_true.to_doc(options.with_prec(Prec::APP)))
+            .append(Doc::space())
+            .append(Doc::text("else"))
+            .append(Doc::space())
+            .append(if_false.to_doc(options.with_prec(Prec::APP))),
+    )
+}
+
 fn pretty_record_ty(inner: StaticDoc) -> StaticDoc {
     Doc::text("Record")
         .append(Doc::space())
@@ -215,6 +237,9 @@ impl ToDoc for RawTerm {
                 &scope.unsafe_body,
             ),
             RawTerm::App(_, ref f, ref a) => pretty_app(options, f, a),
+            RawTerm::If(_, ref cond, ref if_true, ref if_false) => {
+                pretty_if(options, cond, if_true, if_false)
+            },
             RawTerm::RecordType(_, ref label, ref ann, ref rest) => {
                 let mut inner = Doc::nil();
                 let mut label = label;
@@ -296,6 +321,9 @@ impl ToDoc for Term {
                 &scope.unsafe_body,
             ),
             Term::App(_, ref f, ref a) => pretty_app(options, f, a),
+            Term::If(_, ref cond, ref if_true, ref if_false) => {
+                pretty_if(options, cond, if_true, if_false)
+            },
             Term::RecordType(_, ref label, ref ann, ref rest) => {
                 let mut inner = Doc::nil();
                 let mut label = label;
@@ -440,6 +468,9 @@ impl ToDoc for Neutral {
         match *self {
             Neutral::Var(ref var) => pretty_var(options, var),
             Neutral::App(ref fn_term, ref arg_term) => pretty_app(options, fn_term, arg_term),
+            Neutral::If(ref cond, ref if_true, ref if_false) => {
+                pretty_if(options, cond, if_true, if_false)
+            },
             Neutral::Proj(ref expr, ref label) => pretty_proj(options, expr, label),
         }
     }

--- a/src/syntax/translation/concrete_to_core.rs
+++ b/src/syntax/translation/concrete_to_core.rs
@@ -256,6 +256,12 @@ impl ToCore<core::RawTerm> for concrete::Term {
             },
             concrete::Term::App(ref fn_expr, ref args) => app_to_core(fn_expr, args),
             concrete::Term::Let(_, ref _declarations, ref _body) => unimplemented!("let bindings"),
+            concrete::Term::If(start, ref cond, ref if_true, ref if_false) => core::RawTerm::If(
+                Ignore(start),
+                Rc::new(cond.to_core()),
+                Rc::new(if_true.to_core()),
+                Rc::new(if_false.to_core()),
+            ),
             concrete::Term::RecordType(span, ref fields) => record_ty_to_core(span, fields),
             concrete::Term::Record(span, ref fields) => record_to_core(span, fields),
             concrete::Term::Proj(ref tm, label_start, ref label) => {

--- a/src/syntax/translation/core_to_concrete.rs
+++ b/src/syntax/translation/core_to_concrete.rs
@@ -37,9 +37,12 @@ fn parens_if(should_wrap: bool, inner: concrete::Term) -> concrete::Term {
 // const USED_NAMES: &[&str] = &[
 //     // Keywords
 //     "as",
+//     "else",
 //     "_",
 //     "module",
+//     "if",
 //     "import",
+//     "then",
 //     "Type",
 //     // Primitives
 //     "true",
@@ -249,6 +252,15 @@ impl ToConcrete<concrete::Term> for core::Term {
                 concrete::Term::App(
                     Box::new(fn_term.to_concrete_prec(Prec::NO_WRAP)),
                     vec![arg.to_concrete_prec(Prec::NO_WRAP)], // TODO
+                ),
+            ),
+            core::Term::If(_, ref cond, ref if_true, ref if_false) => parens_if(
+                Prec::LAM < prec,
+                concrete::Term::If(
+                    ByteIndex::default(),
+                    Box::new(cond.to_concrete_prec(Prec::APP)),
+                    Box::new(if_true.to_concrete_prec(Prec::APP)),
+                    Box::new(if_false.to_concrete_prec(Prec::APP)),
                 ),
             ),
             core::Term::RecordType(_, ref label, ref ann, ref rest) => {

--- a/src/syntax/translation/core_to_concrete.rs
+++ b/src/syntax/translation/core_to_concrete.rs
@@ -42,6 +42,9 @@ fn parens_if(should_wrap: bool, inner: concrete::Term) -> concrete::Term {
 //     "import",
 //     "Type",
 //     // Primitives
+//     "true",
+//     "false",
+//     "Bool",
 //     "String",
 //     "Char",
 //     "U8",
@@ -114,6 +117,10 @@ impl ToConcrete<concrete::Term> for core::Constant {
         let span = ByteSpan::default();
 
         match *self {
+            // FIXME: Draw these names from some environment?
+            Constant::Bool(true) => Term::Var(span.start(), String::from("true")),
+            Constant::Bool(false) => Term::Var(span.start(), String::from("false")),
+
             Constant::String(ref value) => Term::Literal(span, Literal::String(value.clone())),
             Constant::Char(value) => Term::Literal(span, Literal::Char(value)),
 
@@ -132,6 +139,7 @@ impl ToConcrete<concrete::Term> for core::Constant {
             Constant::F64(value) => Term::Literal(span, Literal::Float(value)),
 
             // FIXME: Draw these names from some environment?
+            Constant::BoolType => Term::Var(span.start(), String::from("Bool")),
             Constant::StringType => Term::Var(span.start(), String::from("String")),
             Constant::CharType => Term::Var(span.start(), String::from("Char")),
             Constant::U8Type => Term::Var(span.start(), String::from("U8")),


### PR DESCRIPTION
We _could_ implement if expressions as as a mix-fix operator, with lazy arguments for the if-true and if-false branches. This is what [Idris does](https://github.com/idris-lang/Idris-dev/blob/d0e06806a256b402075e6a54ca172e7321fa576a/libs/prelude/Prelude/Bool.idr#L12-L18). That would require quite a bit more infrastructure however, so for now I figure it's easier just to add these to the core language.