### PR TITLE
Eagerly apply substitutions

### DIFF
--- a/book/src/appendix/references.md
+++ b/book/src/appendix/references.md
@@ -3,10 +3,6 @@
 What follows is a non-exhaustive list of some of the references that were useful
 when building Pikelet:
 
-- Charguéraud, Arthur (2011). “The Locally Nameless Representation”.
-  In _Journal of Automated Reasoning (JAR)_.
-  [[SITE][ln-site]]
-  [[PAPER][ln-paper]]
 - Christiansen, David Raymond (2013). “Bidirectional Typing Rules: A Tutorial”.
   [[PAPER][bidirectional-typing-paper]]
 - Löh, Andres, McBride, Conor and Swierstra, Wouter (2009). “A tutorial
@@ -17,8 +13,6 @@ when building Pikelet:
   dependent type theory”.
   [[PAPER][agda-paper]]
 
-[ln-site]: http://www.chargueraud.org/softs/ln/
-[ln-paper]: http://www.chargueraud.org/research/2009/ln/main.pdf
 [bidirectional-typing-paper]: http://www.davidchristiansen.dk/tutorials/bidirectional.pdf
 [lambdapi-site]: https://www.andres-loeh.de/LambdaPi/
 [lambdapi-paper]: https://www.andres-loeh.de/LambdaPi/LambdaPi.pdf

--- a/book/src/appendix/theory.md
+++ b/book/src/appendix/theory.md
@@ -327,9 +327,7 @@ in the context.
     \rule{E-APP}{
         \eval{ \Gamma }{ \texpr_1 }{ \lam{x:\vtype_1}{\vexpr_1} }
         \qquad
-        \eval{ \Gamma }{ \texpr_2 }{ \vexpr_2 }
-        \qquad
-        \eval{ \Gamma, x=\vexpr_2 }{ \vexpr_1 }{ \vexpr_3 }
+        \eval{ \Gamma }{ \vexpr_1 ~ [x \rightarrow \texpr_2] }{ \vexpr_3 }
     }{
         \eval{ \Gamma }{ \app{\texpr_1}{\texpr_2} }{ \vexpr_3 }
     }
@@ -523,7 +521,7 @@ returns its elaborated form.
         \qquad
         \check{ \Gamma }{ \rexpr_2 }{ \vtype_1 }{ \texpr_2 }
         \qquad
-        \eval{ \Gamma, x=\texpr_2 }{ \vtype_2 }{ \vtype_3 }
+        \eval{ \Gamma }{ \vtype_2 ~ [x \rightarrow \texpr_2] }{ \vtype_3 }
     }{
         \infer{ \Gamma }{ \app{\rexpr_1}{\rexpr_2} }{ \vtype_3 }{ \app{\texpr_1}{\texpr_2} }
     }

--- a/src/semantics/tests/normalize.rs
+++ b/src/semantics/tests/normalize.rs
@@ -77,7 +77,7 @@ fn lam_app() {
                 (y.clone(), Embed(Rc::new(Value::Universe(Level(0))))),
                 Rc::new(Value::from(Neutral::App(
                     Rc::new(Neutral::Var(Var::Free(x))),
-                    Rc::new(Term::Var(Ignore::default(), Var::Free(y))),
+                    Rc::new(Value::from(Neutral::Var(Var::Free(y)))),
                 ))),
             ))),
         ))),
@@ -106,7 +106,7 @@ fn pi_app() {
                 (y.clone(), Embed(Rc::new(Value::Universe(Level(0))))),
                 Rc::new(Value::from(Neutral::App(
                     Rc::new(Neutral::Var(Var::Free(x))),
-                    Rc::new(Term::Var(Ignore::default(), Var::Free(y))),
+                    Rc::new(Value::from(Neutral::Var(Var::Free(y)))),
                 ))),
             ))),
         ))),
@@ -189,6 +189,32 @@ fn const_app_id_ty() {
             Type
     ";
     let expected_expr = r"\(a : Type) (x : a) => x";
+
+    assert_term_eq!(
+        normalize(&context, &parse_infer(&context, given_expr)).unwrap(),
+        normalize(&context, &parse_infer(&context, expected_expr)).unwrap(),
+    );
+}
+
+#[test]
+fn horrifying_app_1() {
+    let context = Context::default();
+
+    let given_expr = r"(\(t : Type) (f : (a : Type) -> Type) => f t) String (\(a : Type) => a)";
+    let expected_expr = r"String";
+
+    assert_term_eq!(
+        normalize(&context, &parse_infer(&context, given_expr)).unwrap(),
+        normalize(&context, &parse_infer(&context, expected_expr)).unwrap(),
+    );
+}
+
+#[test]
+fn horrifying_app_2() {
+    let context = Context::default();
+
+    let given_expr = r#"(\(t: String) (f: String -> String) => f t) "hello""#;
+    let expected_expr = r#"\(f : String -> String) => f "hello""#;
 
     assert_term_eq!(
         normalize(&context, &parse_infer(&context, given_expr)).unwrap(),

--- a/src/syntax/core.rs
+++ b/src/syntax/core.rs
@@ -493,9 +493,9 @@ pub enum Neutral {
     /// Variables
     Var(Var),
     /// RawTerm application
-    App(Rc<Neutral>, Rc<Term>),
+    App(Rc<Neutral>, Rc<Value>),
     /// If expression
-    If(Rc<Neutral>, Rc<Term>, Rc<Term>),
+    If(Rc<Neutral>, Rc<Value>, Rc<Value>),
     /// Field projection
     Proj(Rc<Neutral>, Label),
 }
@@ -563,14 +563,15 @@ impl<'a> From<&'a Neutral> for Term {
     fn from(src: &'a Neutral) -> Term {
         match *src {
             Neutral::Var(ref var) => Term::Var(Ignore::default(), var.clone()),
-            Neutral::App(ref fn_expr, ref arg_expr) => {
-                Term::App(Rc::new(Term::from(&**fn_expr)), arg_expr.clone())
-            },
+            Neutral::App(ref fn_expr, ref arg_expr) => Term::App(
+                Rc::new(Term::from(&**fn_expr)),
+                Rc::new(Term::from(&**arg_expr)),
+            ),
             Neutral::If(ref cond, ref if_true, ref if_false) => Term::If(
                 Ignore::default(),
                 Rc::new(Term::from(&**cond)),
-                if_true.clone(),
-                if_false.clone(),
+                Rc::new(Term::from(&**if_true)),
+                Rc::new(Term::from(&**if_false)),
             ),
             Neutral::Proj(ref expr, ref name) => Term::Proj(
                 Ignore::default(),


### PR DESCRIPTION
This should fix #22. Alas it might be a little slow performace wise. It might be better to use weak head normal forms and explicit substitutions to improve laziness during type checking. This is a little trickier to get right, but I’ve been working on figuring this out in #56.