### PR TITLE
Use better error reporting for tests

### DIFF
--- a/src/semantics/tests/check.rs
+++ b/src/semantics/tests/check.rs
@@ -2,14 +2,12 @@ use super::*;
 
 #[test]
 fn record() {
+    let mut codemap = CodeMap::new();
     let context = Context::default();
 
     let expected_ty = r"Record { x : F32, y : F32 }";
     let given_expr = r"record { x = 3.0, y = 3.0 }";
 
-    check(
-        &context,
-        &parse(given_expr),
-        &normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
-    ).unwrap();
+    let expected_ty = parse_normalize(&mut codemap, &context, expected_ty);
+    parse_check(&mut codemap, &context, given_expr, &expected_ty);
 }

--- a/src/semantics/tests/check_module.rs
+++ b/src/semantics/tests/check_module.rs
@@ -6,7 +6,7 @@ use super::*;
 fn check_prelude() {
     let mut codemap = CodeMap::new();
     let filemap = codemap.add_filemap(FileName::virtual_("test"), library::PRELUDE.into());
-    let writer = StandardStream::stderr(ColorChoice::Always);
+    let writer = StandardStream::stdout(ColorChoice::Always);
 
     let (concrete_module, errors) = parse::module(&filemap);
     if !errors.is_empty() {

--- a/src/semantics/tests/infer.rs
+++ b/src/semantics/tests/infer.rs
@@ -2,13 +2,14 @@ use super::*;
 
 #[test]
 fn free() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let given_expr = r"x";
     let x = Name::user("x");
 
     assert_eq!(
-        infer(&context, &parse(given_expr)),
+        infer(&context, &parse(&mut codemap, given_expr)),
         Err(TypeError::UndefinedName {
             var_span: ByteSpan::new(ByteIndex(1), ByteIndex(2)),
             name: x,
@@ -18,63 +19,68 @@ fn free() {
 
 #[test]
 fn ty() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"Type 1";
     let given_expr = r"Type";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn ty_levels() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"Type 1";
     let given_expr = r"Type 0 : Type 1 : Type 2 : Type 3"; //... Type ∞       ...+:｡(ﾉ･ω･)ﾉﾞ
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn ann_ty_id() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"Type -> Type";
     let given_expr = r"(\a => a) : Type -> Type";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn ann_arrow_ty_id() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"(Type -> Type) -> (Type -> Type)";
     let given_expr = r"(\a => a) : (Type -> Type) -> (Type -> Type)";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn ann_id_as_ty() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let given_expr = r"(\a => a) : Type";
 
-    match infer(&context, &parse(given_expr)) {
+    match infer(&context, &parse(&mut codemap, given_expr)) {
         Err(TypeError::UnexpectedFunction { .. }) => {},
         other => panic!("unexpected result: {:#?}", other),
     }
@@ -82,25 +88,27 @@ fn ann_id_as_ty() {
 
 #[test]
 fn app() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"Type 1";
     let given_expr = r"(\a : Type 1 => a) Type";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn app_ty() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let given_expr = r"Type Type";
 
     assert_eq!(
-        infer(&context, &parse(given_expr)),
+        infer(&context, &parse(&mut codemap, given_expr)),
         Err(TypeError::ArgAppliedToNonFunction {
             fn_span: ByteSpan::new(ByteIndex(1), ByteIndex(5)),
             arg_span: ByteSpan::new(ByteIndex(6), ByteIndex(10)),
@@ -111,53 +119,57 @@ fn app_ty() {
 
 #[test]
 fn lam() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"(a : Type) -> Type";
     let given_expr = r"\a : Type => a";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn pi() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"Type 1";
     let given_expr = r"(a : Type) -> a";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn id() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"(a : Type) -> a -> a";
     let given_expr = r"\(a : Type) (x : a) => x";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn id_ann() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"(a : Type) -> a -> a";
     let given_expr = r"(\a (x : a) => x) : (A : Type) -> A -> A";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
@@ -165,119 +177,128 @@ fn id_ann() {
 // identity function
 #[test]
 fn id_app_ty() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"Type -> Type";
     let given_expr = r"(\(a : Type 1) (x : a) => x) Type";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 // Passing `Type` to the `Type` identity function should yeild `Type`
 #[test]
 fn id_app_ty_ty() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"Type 1";
     let given_expr = r"(\(a : Type 2) (x : a) => x) (Type 1) Type";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn id_app_ty_arr_ty() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"Type 1";
     let given_expr = r"(\(a : Type 2) (x : a) => x) (Type 1) (Type -> Type)";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn id_app_arr_pi_ty() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"Type -> Type";
     let given_expr = r"(\(a : Type 1) (x : a) => x) (Type -> Type) (\x => x)";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn apply() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"(a b : Type) -> (a -> b) -> a -> b";
     let given_expr = r"\(a b : Type) (f : a -> b) (x : a) => f x";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn const_() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"(a b : Type) -> a -> b -> a";
     let given_expr = r"\(a b : Type) (x : a) (y : b) => x";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn const_flipped() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"(a b : Type) -> a -> b -> b";
     let given_expr = r"\(a b : Type) (x : a) (y : b) => y";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn flip() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"(a b c : Type) -> (a -> b -> c) -> (b -> a -> c)";
     let given_expr = r"\(a b c : Type) (f : a -> b -> c) (y : b) (x : a) => f x y";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn compose() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"(a b c : Type) -> (b -> c) -> (a -> b) -> (a -> c)";
     let given_expr = r"\(a b c : Type) (f : b -> c) (g : a -> b) (x : a) => f (g x)";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
@@ -286,19 +307,21 @@ mod church_encodings {
 
     #[test]
     fn and() {
+        let mut codemap = CodeMap::new();
         let context = Context::new();
 
         let expected_ty = r"Type -> Type -> Type 1";
         let given_expr = r"\(p q : Type) => (c : Type) -> (p -> q -> c) -> c";
 
         assert_term_eq!(
-            infer(&context, &parse(given_expr)).unwrap().1,
-            normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+            parse_infer(&mut codemap, &context, given_expr).1,
+            parse_normalize(&mut codemap, &context, expected_ty),
         );
     }
 
     #[test]
     fn and_intro() {
+        let mut codemap = CodeMap::new();
         let context = Context::new();
 
         let expected_ty = r"
@@ -311,13 +334,14 @@ mod church_encodings {
         ";
 
         assert_term_eq!(
-            infer(&context, &parse(given_expr)).unwrap().1,
-            normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+            parse_infer(&mut codemap, &context, given_expr).1,
+            parse_normalize(&mut codemap, &context, expected_ty),
         );
     }
 
     #[test]
     fn and_proj_left() {
+        let mut codemap = CodeMap::new();
         let context = Context::new();
 
         let expected_ty = r"
@@ -330,13 +354,14 @@ mod church_encodings {
         ";
 
         assert_term_eq!(
-            infer(&context, &parse(given_expr)).unwrap().1,
-            normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+            parse_infer(&mut codemap, &context, given_expr).1,
+            parse_normalize(&mut codemap, &context, expected_ty),
         );
     }
 
     #[test]
     fn and_proj_right() {
+        let mut codemap = CodeMap::new();
         let context = Context::new();
 
         let expected_ty = r"
@@ -348,84 +373,90 @@ mod church_encodings {
         ";
 
         assert_term_eq!(
-            infer(&context, &parse(given_expr)).unwrap().1,
-            normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+            parse_infer(&mut codemap, &context, given_expr).1,
+            parse_normalize(&mut codemap, &context, expected_ty),
         );
     }
 }
 
 #[test]
 fn empty_record_ty() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"Type";
     let given_expr = r"Record {}";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn empty_record() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let expected_ty = r"Record {}";
     let given_expr = r"record {}";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn record_ty() {
+    let mut codemap = CodeMap::new();
     let context = Context::default();
 
     let expected_ty = r"Type 2";
     let given_expr = r"Record { t : Type 1, x : String }";
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn record() {
+    let mut codemap = CodeMap::new();
     let context = Context::default();
 
     let expected_ty = r"Record { t : Type, x : String }";
     let given_expr = r#"record { t = String, x = "hello" }"#;
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn proj() {
+    let mut codemap = CodeMap::new();
     let context = Context::default();
 
     let expected_ty = r"String";
     let given_expr = r#"record { t = String, x = "hello" }.x"#;
 
     assert_term_eq!(
-        infer(&context, &parse(given_expr)).unwrap().1,
-        normalize(&context, &parse_infer(&context, expected_ty)).unwrap(),
+        parse_infer(&mut codemap, &context, given_expr).1,
+        parse_normalize(&mut codemap, &context, expected_ty),
     );
 }
 
 #[test]
 fn proj_missing() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let given_expr = r#"record { x = "hello" }.bloop"#;
 
-    match infer(&context, &parse(given_expr)) {
+    match infer(&context, &parse(&mut codemap, given_expr)) {
         Err(TypeError::NoFieldInType { .. }) => {},
         x => panic!("expected a field lookup error, found {:?}", x),
     }

--- a/src/semantics/tests/mod.rs
+++ b/src/semantics/tests/mod.rs
@@ -8,13 +8,12 @@ use syntax::translation::ToCore;
 
 use super::*;
 
-fn parse(src: &str) -> Rc<RawTerm> {
-    let mut codemap = CodeMap::new();
+fn parse(codemap: &mut CodeMap, src: &str) -> Rc<RawTerm> {
     let filemap = codemap.add_filemap(FileName::virtual_("test"), src.into());
-    let writer = StandardStream::stderr(ColorChoice::Always);
     let (concrete_term, errors) = parse::term(&filemap);
 
     if !errors.is_empty() {
+        let writer = StandardStream::stderr(ColorChoice::Always);
         for error in errors {
             codespan_reporting::emit(&mut writer.lock(), &codemap, &error.to_diagnostic()).unwrap();
         }
@@ -24,10 +23,40 @@ fn parse(src: &str) -> Rc<RawTerm> {
     Rc::new(concrete_term.to_core())
 }
 
-fn parse_infer(context: &Context, src: &str) -> Rc<Term> {
-    infer(context, &parse(src)).unwrap().0
+fn parse_infer(codemap: &mut CodeMap, context: &Context, src: &str) -> (Rc<Term>, Rc<Type>) {
+    match infer(context, &parse(codemap, src)) {
+        Ok((term, ty)) => (term, ty),
+        Err(error) => {
+            let writer = StandardStream::stderr(ColorChoice::Always);
+            codespan_reporting::emit(&mut writer.lock(), &codemap, &error.to_diagnostic()).unwrap();
+            panic!("type error!");
+        },
+    }
 }
 
+fn parse_normalize(codemap: &mut CodeMap, context: &Context, src: &str) -> Rc<Value> {
+    match normalize(context, &parse_infer(codemap, context, src).0) {
+        Ok(value) => value,
+        Err(error) => {
+            let writer = StandardStream::stderr(ColorChoice::Always);
+            codespan_reporting::emit(&mut writer.lock(), &codemap, &error.to_diagnostic()).unwrap();
+            panic!("internal error!");
+        },
+    }
+}
+
+fn parse_check(codemap: &mut CodeMap, context: &Context, src: &str, expected: &Rc<Type>) {
+    match check(context, &parse(codemap, src), expected) {
+        Ok(_) => {},
+        Err(error) => {
+            let writer = StandardStream::stderr(ColorChoice::Always);
+            codespan_reporting::emit(&mut writer.lock(), &codemap, &error.to_diagnostic()).unwrap();
+            panic!("type error!");
+        },
+    }
+}
+
+mod check;
 mod check_module;
 mod infer;
 mod normalize;

--- a/src/semantics/tests/mod.rs
+++ b/src/semantics/tests/mod.rs
@@ -13,7 +13,7 @@ fn parse(codemap: &mut CodeMap, src: &str) -> Rc<RawTerm> {
     let (concrete_term, errors) = parse::term(&filemap);
 
     if !errors.is_empty() {
-        let writer = StandardStream::stderr(ColorChoice::Always);
+        let writer = StandardStream::stdout(ColorChoice::Always);
         for error in errors {
             codespan_reporting::emit(&mut writer.lock(), &codemap, &error.to_diagnostic()).unwrap();
         }
@@ -27,7 +27,7 @@ fn parse_infer(codemap: &mut CodeMap, context: &Context, src: &str) -> (Rc<Term>
     match infer(context, &parse(codemap, src)) {
         Ok((term, ty)) => (term, ty),
         Err(error) => {
-            let writer = StandardStream::stderr(ColorChoice::Always);
+            let writer = StandardStream::stdout(ColorChoice::Always);
             codespan_reporting::emit(&mut writer.lock(), &codemap, &error.to_diagnostic()).unwrap();
             panic!("type error!");
         },
@@ -38,7 +38,7 @@ fn parse_normalize(codemap: &mut CodeMap, context: &Context, src: &str) -> Rc<Va
     match normalize(context, &parse_infer(codemap, context, src).0) {
         Ok(value) => value,
         Err(error) => {
-            let writer = StandardStream::stderr(ColorChoice::Always);
+            let writer = StandardStream::stdout(ColorChoice::Always);
             codespan_reporting::emit(&mut writer.lock(), &codemap, &error.to_diagnostic()).unwrap();
             panic!("internal error!");
         },
@@ -49,7 +49,7 @@ fn parse_check(codemap: &mut CodeMap, context: &Context, src: &str, expected: &R
     match check(context, &parse(codemap, src), expected) {
         Ok(_) => {},
         Err(error) => {
-            let writer = StandardStream::stderr(ColorChoice::Always);
+            let writer = StandardStream::stdout(ColorChoice::Always);
             codespan_reporting::emit(&mut writer.lock(), &codemap, &error.to_diagnostic()).unwrap();
             panic!("type error!");
         },

--- a/src/semantics/tests/normalize.rs
+++ b/src/semantics/tests/normalize.rs
@@ -17,22 +17,24 @@ fn var() {
 
 #[test]
 fn ty() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     assert_term_eq!(
-        normalize(&context, &parse_infer(&context, r"Type")).unwrap(),
+        parse_normalize(&mut codemap, &context, r"Type"),
         Rc::new(Value::Universe(Level(0)))
     );
 }
 
 #[test]
 fn lam() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let x = Name::user("x");
 
     assert_term_eq!(
-        normalize(&context, &parse_infer(&context, r"\x : Type => x")).unwrap(),
+        parse_normalize(&mut codemap, &context, r"\x : Type => x"),
         Rc::new(Value::Lam(nameless::bind(
             (x.clone(), Embed(Rc::new(Value::Universe(Level(0))))),
             Rc::new(Value::from(Neutral::Var(Var::Free(x)))),
@@ -42,12 +44,13 @@ fn lam() {
 
 #[test]
 fn pi() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let x = Name::user("x");
 
     assert_term_eq!(
-        normalize(&context, &parse_infer(&context, r"(x : Type) -> x")).unwrap(),
+        parse_normalize(&mut codemap, &context, r"(x : Type) -> x"),
         Rc::new(Value::Pi(nameless::bind(
             (x.clone(), Embed(Rc::new(Value::Universe(Level(0))))),
             Rc::new(Value::from(Neutral::Var(Var::Free(x)))),
@@ -57,6 +60,7 @@ fn pi() {
 
 #[test]
 fn lam_app() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let x = Name::user("x");
@@ -67,10 +71,11 @@ fn lam_app() {
     )));
 
     assert_term_eq!(
-        normalize(
+        parse_normalize(
+            &mut codemap,
             &context,
-            &parse_infer(&context, r"\(x : Type -> Type) (y : Type) => x y")
-        ).unwrap(),
+            r"\(x : Type -> Type) (y : Type) => x y"
+        ),
         Rc::new(Value::Lam(nameless::bind(
             (x.clone(), Embed(ty_arr)),
             Rc::new(Value::Lam(nameless::bind(
@@ -86,6 +91,7 @@ fn lam_app() {
 
 #[test]
 fn pi_app() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let x = Name::user("x");
@@ -96,10 +102,11 @@ fn pi_app() {
     )));
 
     assert_term_eq!(
-        normalize(
+        parse_normalize(
+            &mut codemap,
             &context,
-            &parse_infer(&context, r"(x : Type -> Type) -> (y : Type) -> x y")
-        ).unwrap(),
+            r"(x : Type -> Type) -> (y : Type) -> x y"
+        ),
         Rc::new(Value::Pi(nameless::bind(
             (x.clone(), Embed(ty_arr)),
             Rc::new(Value::Pi(nameless::bind(
@@ -117,28 +124,30 @@ fn pi_app() {
 // identity function
 #[test]
 fn id_app_ty() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let given_expr = r"(\(a : Type 1) (x : a) => x) Type";
     let expected_expr = r"\x : Type => x";
 
     assert_term_eq!(
-        normalize(&context, &parse_infer(&context, given_expr)).unwrap(),
-        normalize(&context, &parse_infer(&context, expected_expr)).unwrap(),
+        parse_normalize(&mut codemap, &context, given_expr),
+        parse_normalize(&mut codemap, &context, expected_expr),
     );
 }
 
 // Passing `Type` to the `Type` identity function should yeild `Type`
 #[test]
 fn id_app_ty_ty() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let given_expr = r"(\(a : Type 2) (x : a) => x) (Type 1) Type";
     let expected_expr = r"Type";
 
     assert_term_eq!(
-        normalize(&context, &parse_infer(&context, given_expr)).unwrap(),
-        normalize(&context, &parse_infer(&context, expected_expr)).unwrap(),
+        parse_normalize(&mut codemap, &context, given_expr),
+        parse_normalize(&mut codemap, &context, expected_expr),
     );
 }
 
@@ -146,20 +155,22 @@ fn id_app_ty_ty() {
 // `Type -> Type`
 #[test]
 fn id_app_ty_arr_ty() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let given_expr = r"(\(a : Type 2) (x : a) => x) (Type 1) (Type -> Type)";
     let expected_expr = r"Type -> Type";
 
     assert_term_eq!(
-        normalize(&context, &parse_infer(&context, given_expr)).unwrap(),
-        normalize(&context, &parse_infer(&context, expected_expr)).unwrap(),
+        parse_normalize(&mut codemap, &context, given_expr),
+        parse_normalize(&mut codemap, &context, expected_expr),
     );
 }
 
 // Passing the id function to itself should yield the id function
 #[test]
 fn id_app_id() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let given_expr = r"
@@ -170,8 +181,8 @@ fn id_app_id() {
     let expected_expr = r"\(a : Type) (x : a) => x";
 
     assert_term_eq!(
-        normalize(&context, &parse_infer(&context, given_expr)).unwrap(),
-        normalize(&context, &parse_infer(&context, expected_expr)).unwrap(),
+        parse_normalize(&mut codemap, &context, given_expr),
+        parse_normalize(&mut codemap, &context, expected_expr),
     );
 }
 
@@ -179,6 +190,7 @@ fn id_app_id() {
 // function that always returns the id function
 #[test]
 fn const_app_id_ty() {
+    let mut codemap = CodeMap::new();
     let context = Context::new();
 
     let given_expr = r"
@@ -191,33 +203,35 @@ fn const_app_id_ty() {
     let expected_expr = r"\(a : Type) (x : a) => x";
 
     assert_term_eq!(
-        normalize(&context, &parse_infer(&context, given_expr)).unwrap(),
-        normalize(&context, &parse_infer(&context, expected_expr)).unwrap(),
+        parse_normalize(&mut codemap, &context, given_expr),
+        parse_normalize(&mut codemap, &context, expected_expr),
     );
 }
 
 #[test]
 fn horrifying_app_1() {
+    let mut codemap = CodeMap::new();
     let context = Context::default();
 
     let given_expr = r"(\(t : Type) (f : (a : Type) -> Type) => f t) String (\(a : Type) => a)";
     let expected_expr = r"String";
 
     assert_term_eq!(
-        normalize(&context, &parse_infer(&context, given_expr)).unwrap(),
-        normalize(&context, &parse_infer(&context, expected_expr)).unwrap(),
+        parse_normalize(&mut codemap, &context, given_expr),
+        parse_normalize(&mut codemap, &context, expected_expr),
     );
 }
 
 #[test]
 fn horrifying_app_2() {
+    let mut codemap = CodeMap::new();
     let context = Context::default();
 
     let given_expr = r#"(\(t: String) (f: String -> String) => f t) "hello""#;
     let expected_expr = r#"\(f : String -> String) => f "hello""#;
 
     assert_term_eq!(
-        normalize(&context, &parse_infer(&context, given_expr)).unwrap(),
-        normalize(&context, &parse_infer(&context, expected_expr)).unwrap(),
+        parse_normalize(&mut codemap, &context, given_expr),
+        parse_normalize(&mut codemap, &context, expected_expr),
     );
 }

--- a/src/syntax/translation/concrete_to_core.rs
+++ b/src/syntax/translation/concrete_to_core.rs
@@ -307,7 +307,7 @@ mod to_core {
         fn parse_prelude() {
             let mut codemap = CodeMap::new();
             let filemap = codemap.add_filemap(FileName::virtual_("test"), library::PRELUDE.into());
-            let writer = StandardStream::stderr(ColorChoice::Always);
+            let writer = StandardStream::stdout(ColorChoice::Always);
 
             let (concrete_module, errors) = parse::module(&filemap);
             if !errors.is_empty() {


### PR DESCRIPTION
After peering for ages at the Debug output of the test failures in #47 I finally bit the bullet and used codespan_reporting for type errors in our tests.