### PR TITLE
Remove hard-coded type constants

### DIFF
--- a/src/semantics/errors.rs
+++ b/src/semantics/errors.rs
@@ -5,7 +5,7 @@ use codespan_reporting::{Diagnostic, Label};
 use nameless::{BoundName, Name};
 
 use syntax::concrete;
-use syntax::core::{self, RawConstant};
+use syntax::core::{self, RawLiteral};
 
 /// An internal error. These are bugs!
 #[derive(Debug, Fail, Clone, PartialEq)]
@@ -81,7 +81,7 @@ pub enum TypeError {
     #[fail(display = "found a `{}`, but expected a type `{}`", found, expected)]
     LiteralMismatch {
         literal_span: ByteSpan,
-        found: RawConstant,
+        found: RawLiteral,
         expected: Box<concrete::Term>,
     },
     #[fail(display = "Ambiguous integer literal")]
@@ -160,10 +160,10 @@ impl TypeError {
                 ref expected,
             } => {
                 let found_text = match *found {
-                    RawConstant::String(_) => "string",
-                    RawConstant::Char(_) => "character",
-                    RawConstant::Int(_) => "numeric",
-                    RawConstant::Float(_) => "floating point",
+                    RawLiteral::String(_) => "string",
+                    RawLiteral::Char(_) => "character",
+                    RawLiteral::Int(_) => "numeric",
+                    RawLiteral::Float(_) => "floating point",
                 };
 
                 Diagnostic::new_error(format!(

--- a/src/syntax/context.rs
+++ b/src/syntax/context.rs
@@ -1,5 +1,5 @@
 use im::Vector;
-use nameless::{Ignore, Name};
+use nameless::{Ignore, Name, Var};
 use std::fmt;
 use std::rc::Rc;
 
@@ -85,30 +85,29 @@ impl Context {
 
 impl Default for Context {
     fn default() -> Context {
-        use syntax::core::Constant::*;
-        use syntax::core::{Level, Value};
+        use syntax::core::{Level, Literal, Value};
 
         let name = Name::user;
+        let free_var = |n| Rc::new(Value::from(Var::Free(name(n))));
         let universe0 = Rc::new(Value::Universe(Level(0)));
-        let constant = |c| Rc::new(Term::Constant(Ignore::default(), c));
-        let constant_val = |c| Rc::new(Value::Constant(c));
+        let bool_lit = |val| Rc::new(Term::Literal(Ignore::default(), Literal::Bool(val)));
 
         Context::new()
-            .define_term(name("true"), constant_val(BoolType), constant(Bool(true)))
-            .define_term(name("false"), constant_val(BoolType), constant(Bool(false)))
-            .define_term(name("Bool"), universe0.clone(), constant(BoolType))
-            .define_term(name("String"), universe0.clone(), constant(StringType))
-            .define_term(name("Char"), universe0.clone(), constant(CharType))
-            .define_term(name("U8"), universe0.clone(), constant(U8Type))
-            .define_term(name("U16"), universe0.clone(), constant(U16Type))
-            .define_term(name("U32"), universe0.clone(), constant(U32Type))
-            .define_term(name("U64"), universe0.clone(), constant(U64Type))
-            .define_term(name("I8"), universe0.clone(), constant(I8Type))
-            .define_term(name("I16"), universe0.clone(), constant(I16Type))
-            .define_term(name("I32"), universe0.clone(), constant(I32Type))
-            .define_term(name("I64"), universe0.clone(), constant(I64Type))
-            .define_term(name("F32"), universe0.clone(), constant(F32Type))
-            .define_term(name("F64"), universe0.clone(), constant(F64Type))
+            .claim(name("Bool"), universe0.clone())
+            .define_term(name("true"), free_var("Bool"), bool_lit(true))
+            .define_term(name("false"), free_var("Bool"), bool_lit(false))
+            .claim(name("String"), universe0.clone())
+            .claim(name("Char"), universe0.clone())
+            .claim(name("U8"), universe0.clone())
+            .claim(name("U16"), universe0.clone())
+            .claim(name("U32"), universe0.clone())
+            .claim(name("U64"), universe0.clone())
+            .claim(name("I8"), universe0.clone())
+            .claim(name("I16"), universe0.clone())
+            .claim(name("I32"), universe0.clone())
+            .claim(name("I64"), universe0.clone())
+            .claim(name("F32"), universe0.clone())
+            .claim(name("F64"), universe0.clone())
             .define_prim(name("prim-string-eq"), Rc::new(prim::string_eq()))
             .define_prim(name("prim-bool-eq"), Rc::new(prim::bool_eq()))
             .define_prim(name("prim-char-eq"), Rc::new(prim::char_eq()))

--- a/src/syntax/pretty/core.rs
+++ b/src/syntax/pretty/core.rs
@@ -5,8 +5,8 @@ use pretty::Doc;
 use std::iter;
 
 use syntax::core::{
-    Constant, Definition, Head, Label, Level, Module, Neutral, RawConstant, RawDefinition,
-    RawModule, RawTerm, Term, Value,
+    Definition, Head, Label, Level, Literal, Module, Neutral, RawDefinition, RawLiteral, RawModule,
+    RawTerm, Term, Value,
 };
 
 use super::{parens, sexpr, StaticDoc, ToDoc};
@@ -100,47 +100,34 @@ fn pretty_proj<E: ToDoc>(expr: &E, label: &Label) -> StaticDoc {
     )
 }
 
-impl ToDoc for RawConstant {
+impl ToDoc for RawLiteral {
     fn to_doc(&self) -> StaticDoc {
         match *self {
-            RawConstant::String(ref value) => Doc::text(format!("{:?}", value)),
-            RawConstant::Char(value) => Doc::text(format!("{:?}", value)),
-            RawConstant::Int(value) => Doc::as_string(value),
-            RawConstant::Float(value) => Doc::as_string(value),
+            RawLiteral::String(ref value) => Doc::text(format!("{:?}", value)),
+            RawLiteral::Char(value) => Doc::text(format!("{:?}", value)),
+            RawLiteral::Int(value) => Doc::as_string(value),
+            RawLiteral::Float(value) => Doc::as_string(value),
         }
     }
 }
 
-impl ToDoc for Constant {
+impl ToDoc for Literal {
     fn to_doc(&self) -> StaticDoc {
         match *self {
-            Constant::Bool(true) => Doc::text("#true"),
-            Constant::Bool(false) => Doc::text("#false"),
-            Constant::String(ref value) => Doc::text(format!("{:?}", value)),
-            Constant::Char(value) => Doc::text(format!("{:?}", value)),
-            Constant::U8(value) => Doc::as_string(value),
-            Constant::U16(value) => Doc::as_string(value),
-            Constant::U32(value) => Doc::as_string(value),
-            Constant::U64(value) => Doc::as_string(value),
-            Constant::I8(value) => Doc::as_string(value),
-            Constant::I16(value) => Doc::as_string(value),
-            Constant::I32(value) => Doc::as_string(value),
-            Constant::I64(value) => Doc::as_string(value),
-            Constant::F32(value) => Doc::as_string(value),
-            Constant::F64(value) => Doc::as_string(value),
-            Constant::BoolType => Doc::text("#Bool"),
-            Constant::StringType => Doc::text("#String"),
-            Constant::CharType => Doc::text("#Char"),
-            Constant::U8Type => Doc::text("#U8"),
-            Constant::U16Type => Doc::text("#U16"),
-            Constant::U32Type => Doc::text("#U32"),
-            Constant::U64Type => Doc::text("#U64"),
-            Constant::I8Type => Doc::text("#I8"),
-            Constant::I16Type => Doc::text("#I16"),
-            Constant::I32Type => Doc::text("#I32"),
-            Constant::I64Type => Doc::text("#I64"),
-            Constant::F32Type => Doc::text("#F32"),
-            Constant::F64Type => Doc::text("#F64"),
+            Literal::Bool(true) => Doc::text("true"),
+            Literal::Bool(false) => Doc::text("false"),
+            Literal::String(ref value) => Doc::text(format!("{:?}", value)),
+            Literal::Char(value) => Doc::text(format!("{:?}", value)),
+            Literal::U8(value) => Doc::as_string(value),
+            Literal::U16(value) => Doc::as_string(value),
+            Literal::U32(value) => Doc::as_string(value),
+            Literal::U64(value) => Doc::as_string(value),
+            Literal::I8(value) => Doc::as_string(value),
+            Literal::I16(value) => Doc::as_string(value),
+            Literal::I32(value) => Doc::as_string(value),
+            Literal::I64(value) => Doc::as_string(value),
+            Literal::F32(value) => Doc::as_string(value),
+            Literal::F64(value) => Doc::as_string(value),
         }
     }
 }
@@ -151,7 +138,7 @@ impl ToDoc for RawTerm {
             RawTerm::Ann(_, ref expr, ref ty) => pretty_ann(expr, ty),
             RawTerm::Universe(_, level) => pretty_universe(level),
             RawTerm::Hole(_) => parens(Doc::text("hole")),
-            RawTerm::Constant(_, ref c) => c.to_doc(),
+            RawTerm::Literal(_, ref lit) => lit.to_doc(),
             RawTerm::Var(_, ref var) => pretty_var(var),
             RawTerm::Lam(_, ref scope) => pretty_lam(
                 &scope.unsafe_pattern.0,
@@ -229,7 +216,7 @@ impl ToDoc for Term {
         match *self {
             Term::Ann(_, ref expr, ref ty) => pretty_ann(expr, ty),
             Term::Universe(_, level) => pretty_universe(level),
-            Term::Constant(_, ref c) => c.to_doc(),
+            Term::Literal(_, ref lit) => lit.to_doc(),
             Term::Var(_, ref var) => pretty_var(var),
             Term::Lam(_, ref scope) => pretty_lam(
                 &scope.unsafe_pattern.0,
@@ -304,7 +291,7 @@ impl ToDoc for Value {
     fn to_doc(&self) -> StaticDoc {
         match *self {
             Value::Universe(level) => pretty_universe(level),
-            Value::Constant(ref c) => c.to_doc(),
+            Value::Literal(ref lit) => lit.to_doc(),
             Value::Lam(ref scope) => pretty_lam(
                 &scope.unsafe_pattern.0,
                 &(scope.unsafe_pattern.1).0,

--- a/src/syntax/prim.rs
+++ b/src/syntax/prim.rs
@@ -1,9 +1,10 @@
 //! Primitive operations
 
+use nameless::{Name, Var};
 use std::fmt;
 use std::rc::Rc;
 
-use syntax::core::{Constant, Type, Value};
+use syntax::core::{Literal, Type, Value};
 
 // Some helper traits for marshalling beteen Rust and Pikelet values
 //
@@ -25,7 +26,7 @@ macro_rules! impl_into_value {
     ($T:ty, $Variant:ident) => {
         impl IntoValue for $T {
             fn into_value(self) -> Rc<Value> {
-                Rc::new(Value::Constant(Constant::$Variant(self)))
+                Rc::new(Value::Literal(Literal::$Variant(self)))
             }
         }
     };
@@ -50,7 +51,7 @@ macro_rules! impl_try_from_value_ref {
         impl TryFromValueRef for $T {
             fn try_from_value_ref(src: &Value) -> Result<&Self, ()> {
                 match *src {
-                    Value::Constant(Constant::$Variant(ref x)) => Ok(x),
+                    Value::Literal(Literal::$Variant(ref x)) => Ok(x),
                     _ => Err(()),
                 }
             }
@@ -73,28 +74,28 @@ impl_try_from_value_ref!(f32, F32);
 impl_try_from_value_ref!(f64, F64);
 
 macro_rules! impl_has_ty {
-    ($T:ty, $ty:expr) => {
+    ($T:ty, $ty_name:expr) => {
         impl HasType for $T {
             fn ty() -> Rc<Type> {
-                $ty
+                Rc::new(Value::from(Var::Free(Name::user($ty_name))))
             }
         }
     };
 }
 
-impl_has_ty!(String, Rc::new(Value::Constant(Constant::StringType)));
-impl_has_ty!(char, Rc::new(Value::Constant(Constant::CharType)));
-impl_has_ty!(bool, Rc::new(Value::Constant(Constant::BoolType)));
-impl_has_ty!(u8, Rc::new(Value::Constant(Constant::U8Type)));
-impl_has_ty!(u16, Rc::new(Value::Constant(Constant::U16Type)));
-impl_has_ty!(u32, Rc::new(Value::Constant(Constant::U32Type)));
-impl_has_ty!(u64, Rc::new(Value::Constant(Constant::U64Type)));
-impl_has_ty!(i8, Rc::new(Value::Constant(Constant::I8Type)));
-impl_has_ty!(i16, Rc::new(Value::Constant(Constant::I16Type)));
-impl_has_ty!(i32, Rc::new(Value::Constant(Constant::I32Type)));
-impl_has_ty!(i64, Rc::new(Value::Constant(Constant::I64Type)));
-impl_has_ty!(f32, Rc::new(Value::Constant(Constant::F32Type)));
-impl_has_ty!(f64, Rc::new(Value::Constant(Constant::F64Type)));
+impl_has_ty!(String, "String");
+impl_has_ty!(char, "Char");
+impl_has_ty!(bool, "Bool");
+impl_has_ty!(u8, "U8");
+impl_has_ty!(u16, "U16");
+impl_has_ty!(u32, "U32");
+impl_has_ty!(u64, "U64");
+impl_has_ty!(i8, "I8");
+impl_has_ty!(i16, "I16");
+impl_has_ty!(i32, "I32");
+impl_has_ty!(i64, "I64");
+impl_has_ty!(f32, "F32");
+impl_has_ty!(f64, "F64");
 
 /// Primitive functions
 #[derive(Clone)]

--- a/src/syntax/translation/desugar/mod.rs
+++ b/src/syntax/translation/desugar/mod.rs
@@ -247,16 +247,16 @@ impl Desugar<core::RawTerm> for concrete::Term {
                 core::RawTerm::Universe(span, core::Level(level.unwrap_or(0)))
             },
             concrete::Term::String(_, ref value) => {
-                core::RawTerm::Constant(span, core::RawConstant::String(value.clone()))
+                core::RawTerm::Literal(span, core::RawLiteral::String(value.clone()))
             },
             concrete::Term::Char(_, value) => {
-                core::RawTerm::Constant(span, core::RawConstant::Char(value))
+                core::RawTerm::Literal(span, core::RawLiteral::Char(value))
             },
             concrete::Term::Int(_, value) => {
-                core::RawTerm::Constant(span, core::RawConstant::Int(value))
+                core::RawTerm::Literal(span, core::RawLiteral::Int(value))
             },
             concrete::Term::Float(_, value) => {
-                core::RawTerm::Constant(span, core::RawConstant::Float(value))
+                core::RawTerm::Literal(span, core::RawLiteral::Float(value))
             },
             concrete::Term::Array(_, ref _elems) => unimplemented!("array literals"),
             concrete::Term::Hole(_) => core::RawTerm::Hole(span),

--- a/src/syntax/translation/resugar.rs
+++ b/src/syntax/translation/resugar.rs
@@ -106,45 +106,30 @@ fn parens_if(should_wrap: bool, inner: concrete::Term) -> concrete::Term {
 //     "F64",
 // ];
 
-fn resugar_constant(constant: &core::Constant) -> concrete::Term {
+fn resugar_literal(constant: &core::Literal) -> concrete::Term {
     let span = ByteSpan::default();
 
     match *constant {
         // FIXME: Draw these names from some environment?
-        core::Constant::Bool(true) => concrete::Term::Var(span.start(), String::from("true")),
-        core::Constant::Bool(false) => concrete::Term::Var(span.start(), String::from("false")),
+        core::Literal::Bool(true) => concrete::Term::Var(span.start(), String::from("true")),
+        core::Literal::Bool(false) => concrete::Term::Var(span.start(), String::from("false")),
 
-        core::Constant::String(ref value) => concrete::Term::String(span, value.clone()),
-        core::Constant::Char(value) => concrete::Term::Char(span, value),
+        core::Literal::String(ref value) => concrete::Term::String(span, value.clone()),
+        core::Literal::Char(value) => concrete::Term::Char(span, value),
 
-        core::Constant::U8(value) => concrete::Term::Int(span, value as u64),
-        core::Constant::U16(value) => concrete::Term::Int(span, value as u64),
-        core::Constant::U32(value) => concrete::Term::Int(span, value as u64),
-        core::Constant::U64(value) => concrete::Term::Int(span, value),
+        core::Literal::U8(value) => concrete::Term::Int(span, value as u64),
+        core::Literal::U16(value) => concrete::Term::Int(span, value as u64),
+        core::Literal::U32(value) => concrete::Term::Int(span, value as u64),
+        core::Literal::U64(value) => concrete::Term::Int(span, value),
 
         // FIXME: Underflow for negative numbers
-        core::Constant::I8(value) => concrete::Term::Int(span, value as u64),
-        core::Constant::I16(value) => concrete::Term::Int(span, value as u64),
-        core::Constant::I32(value) => concrete::Term::Int(span, value as u64),
-        core::Constant::I64(value) => concrete::Term::Int(span, value as u64),
+        core::Literal::I8(value) => concrete::Term::Int(span, value as u64),
+        core::Literal::I16(value) => concrete::Term::Int(span, value as u64),
+        core::Literal::I32(value) => concrete::Term::Int(span, value as u64),
+        core::Literal::I64(value) => concrete::Term::Int(span, value as u64),
 
-        core::Constant::F32(value) => concrete::Term::Float(span, value as f64),
-        core::Constant::F64(value) => concrete::Term::Float(span, value),
-
-        // FIXME: Draw these names from some environment?
-        core::Constant::BoolType => concrete::Term::Var(span.start(), String::from("Bool")),
-        core::Constant::StringType => concrete::Term::Var(span.start(), String::from("String")),
-        core::Constant::CharType => concrete::Term::Var(span.start(), String::from("Char")),
-        core::Constant::U8Type => concrete::Term::Var(span.start(), String::from("U8")),
-        core::Constant::U16Type => concrete::Term::Var(span.start(), String::from("U16")),
-        core::Constant::U32Type => concrete::Term::Var(span.start(), String::from("U32")),
-        core::Constant::U64Type => concrete::Term::Var(span.start(), String::from("U64")),
-        core::Constant::I8Type => concrete::Term::Var(span.start(), String::from("I8")),
-        core::Constant::I16Type => concrete::Term::Var(span.start(), String::from("I16")),
-        core::Constant::I32Type => concrete::Term::Var(span.start(), String::from("I32")),
-        core::Constant::I64Type => concrete::Term::Var(span.start(), String::from("I64")),
-        core::Constant::F32Type => concrete::Term::Var(span.start(), String::from("F32")),
-        core::Constant::F64Type => concrete::Term::Var(span.start(), String::from("F64")),
+        core::Literal::F32(value) => concrete::Term::Float(span, value as f64),
+        core::Literal::F64(value) => concrete::Term::Float(span, value),
     }
 }
 
@@ -324,7 +309,7 @@ fn resugar_term(term: &core::Term, prec: Prec) -> concrete::Term {
                 concrete::Term::Universe(ByteSpan::default(), level),
             )
         },
-        core::Term::Constant(_, ref c) => resugar_constant(c),
+        core::Term::Literal(_, ref lit) => resugar_literal(lit),
         core::Term::Var(_, Var::Free(Name::User(ref name))) => {
             concrete::Term::Var(ByteIndex::default(), name.to_string())
         },
@@ -416,9 +401,9 @@ fn resugar_term(term: &core::Term, prec: Prec) -> concrete::Term {
     }
 }
 
-impl Resugar<concrete::Term> for core::Constant {
+impl Resugar<concrete::Term> for core::Literal {
     fn resugar(&self) -> concrete::Term {
-        resugar_constant(self)
+        resugar_literal(self)
     }
 }
 


### PR DESCRIPTION
Not sure about this one. This makes primitive types just empty type claims in the context associated definitions. We can then just refer to them using free variables in the type checker. 🤷‍♂️ 