### PR TITLE
Re-enable CI for Rust stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ cache:
   directories:
     - book/highlight.js/node_modules
 rust:
-  # FIXME: Blocked on slice pattern stabilization (lands in 1.26)
-  # - 1.26.0
-  # - stable
+  - 1.26.0
+  - stable
   - beta
   - nightly
 


### PR DESCRIPTION
Re-enabling Travis checking for Rust stable now that result-in-main and slice patterns have been stabilised. I’ve also pinned the lowest stable version to `1.26.0` as documentation for folks in the future.