### PR TITLE
docs: Fix minor typos, sentence structure in the Language Book

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -20,7 +20,7 @@ mdbook serve
 
 Highlight.js can be [hard to extend][mdbook-custom-highlighting-issue], so we've
 had to make a [custom fork][highlightjs-fork] that supports Pikelet syntax. For
-better our worse, we've included this as a submodule as a temporary solution.
+better or worse, we've included this as a submodule as a temporary solution.
 To build this, we've included a handy script:
 
 ```sh

--- a/book/src/appendix/design.md
+++ b/book/src/appendix/design.md
@@ -8,7 +8,7 @@ Pikelet should feel:
 - Liberating
 - Sympathetic
 
-This is a rough list things that might be interesting to explore with Pikelet:
+This is a rough list of things that might be interesting to explore with Pikelet:
 
 - Sympathetic to humans
     - Programs should look pretty, and read clearly

--- a/book/src/language/conditionals.md
+++ b/book/src/language/conditionals.md
@@ -2,7 +2,7 @@
 
 ## If-then-else expressions
 
-If expressions take an expression that evaluates to a `Bool` (the _condition_),
+`if` expressions take an expression that evaluates to a `Bool` (the _condition_),
 and two other expressions (the _consequent_ and the _alternative_) that evaluate
 to the same type. If the condition evaluates to `true`, then the consequent will
 be evaluated and returned, otherwise the alternative will be evaluated and

--- a/book/src/language/functions.md
+++ b/book/src/language/functions.md
@@ -65,7 +65,7 @@ Pikelet> (\(x : Type) (x : a) => x) I32 1
 
 ## Syntactic sugar for functions
 
-In Pikelet all functions take a single argument - in order to pass multiple
+In Pikelet, all functions take a single argument - in order to pass multiple
 arguments we use currying. The following functions are equivalent:
 
 ```pikelet

--- a/book/src/language/index.md
+++ b/book/src/language/index.md
@@ -27,7 +27,7 @@ name = String;
 
 ## Comments
 
-Line comments are proceeded by a double dash:
+Line comments are preceded by a double dash:
 
 ```pikelet
 -- this is a comment!
@@ -41,7 +41,7 @@ Block comments go between curly-dashes like so:
 -}
 ```
 
-Doc comments are proceeded by a triple pipe, and are used to document
+Doc comments are preceded by a triple pipe, and are used to document
 definitions:
 
 ```pikelet

--- a/book/src/language/records.md
+++ b/book/src/language/records.md
@@ -19,7 +19,7 @@ Take note of the following:
 
 - record values use the lower case `record` keyword
 - record types use the upper case `Record` keyword
-- we had to [annotate](#type-annotations) ambiguous field values
+- we have to [annotate](#type-annotations) ambiguous field values
 
 We can make a new definition for point types:
 
@@ -37,7 +37,7 @@ Pikelet> record { x = 3.0; y = 3.0 } : Point2d
 record { x = 3; y = 3 } : Record { x : F32; y : F32 }
 ```
 
-Note thaw we no longer need to annotate each field! Pikelet was able to pick up
+Note that we no longer need to annotate each field! Pikelet was able to pick up
 the type of each field from the type definition during type checking. You can
 read more about Pikelet's type inference on [the type inference page](./type-inference).
 

--- a/book/src/language/type-inference.md
+++ b/book/src/language/type-inference.md
@@ -1,6 +1,6 @@
 # Type inference
 
-Many statically typed languages perform type inference, to varying degrees, and
+Many statically typed languages perform type inference to varying degrees, and
 Pikelet is no different! The goal is to reduce the burden of writing type
 annotations everywhere. Some languages like [OCaml](https://ocaml.org/) and
 [Elm](http://elm-lang.org/) can even infer the types of a whole program without
@@ -8,7 +8,7 @@ any annotations at all!
 
 Pikelet's type inference follows some very simple rules that you can probably
 pick up on your own, but we thought it might help to give a deeper explanation
-of how it works, without getting to bogged down in the theoretical details.
+of how it works, without getting too bogged down in the theoretical details.
 
 ## Contents
 

--- a/book/src/language/types-of-types.md
+++ b/book/src/language/types-of-types.md
@@ -21,7 +21,7 @@ Pikelet> :t Type 0
 Type 1
 ```
 
-In fact Pikelet has an infinte number of 'universes', each one 'bigger' than the
+In fact, Pikelet has an infinte number of 'universes', each one 'bigger' than the
 previous:
 
 ```pikelet-repl


### PR DESCRIPTION
docs: Fix typo: our -> or

docs: proceeded -> preceded

docs: Inline code block to more clearly reference `if` expression

docs: Use present tense for instruction

docs: Fix typo: thaw -> that

docs: Opinion: add comma for better structure

docs: Opinion: remove comma for better structure

docs: Fix typo: to -> too

docs: Opinion: add comma for better structure

docs: Fix missing preposition: list things -> list of things